### PR TITLE
add a voucher_subscriber option

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,11 @@ builds:
     binary: voucher_server
     env:
       - CGO_ENABLED=0
+  - id: voucher_subscriber
+    main: ./cmd/voucher_subscriber
+    binary: voucher_subscriber
+    env:
+      - CGO_ENABLED=0
   - id: voucher_client
     main: ./cmd/voucher_client
     binary: voucher_client
@@ -18,6 +23,18 @@ archives:
     builds:
       - voucher_server
     name_template: "voucher_server_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    files:
+      - LICENSE
+    wrap_in_directory: true
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      amd64: x86_64
+  - id: voucher_subscriber
+    builds:
+      - voucher_subscriber
+    name_template: "voucher_subscriber_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     files:
       - LICENSE
     wrap_in_directory: true

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ DOCKER=docker
 GOPATH?=`echo $$GOPATH`
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
-PACKAGES := voucher_server voucher_client
+PACKAGES := voucher_server voucher_subscriber voucher_client
 CODE=./cmd/
 SERVER_NAME=voucher_server
+SUBSCRIBER_NAME=voucher_subscriber
 CLIENT_NAME=voucher_client
 IMAGE_NAME?=voucher
 
@@ -68,6 +69,9 @@ build: $(PACKAGES)
 
 voucher_client:
 	$(GOBUILD) -o build/$(CLIENT_NAME) -v $(CODE)$(CLIENT_NAME)
+
+voucher_subscriber:
+	$(GOBUILD) -o build/$(SUBSCRIBER_NAME) -v $(CODE)$(SUBSCRIBER_NAME)
 
 voucher_server:
 	$(GOBUILD) -o build/$(SERVER_NAME) -v $(CODE)$(SERVER_NAME)

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ As well as the following dynamic check:
 
 Note that `provenance` and the dynamic checks require the prescence of build metadata in your metadata store. While unsigned metadata is valid, to ensure that you are trusting metadata that hasn't been forged, it is recommended that you use signed metadata as well.
 
-## Voucher Server and Client
+## Voucher Server, Subscriber, and Client
 
-This repository contains two tools: Voucher server, intended to run in your infrastructure to respond to CI/CD pipeline requests, and Voucher client, an example of a Voucher API client that you can use directly in your CI/CD pipeline or as a basis for your own code.
-
-- [Server](cmd/voucher_server/README.md)
-- [Client](cmd/voucher_client/README.md)
+This repository contains three tools:
+- [Voucher server](cmd/voucher_server/README.md): intended to run in your infrastructure to respond to CI/CD pipeline requests.
+- [Voucher subscriber](cmd/voucher_subscriber/README.md): intended to listen for pub/sub messages for image creations and automatically vouch images.
+- [Voucher client](cmd/voucher_client/README.md): an example of a Voucher API client that you can use directly in your CI/CD pipeline or as a basis for your own code.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Note that `provenance` and the dynamic checks require the prescence of build met
 ## Voucher Server, Subscriber, and Client
 
 This repository contains three tools:
-- [Voucher server](cmd/voucher_server/README.md): intended to run in your infrastructure to respond to CI/CD pipeline requests.
-- [Voucher subscriber](cmd/voucher_subscriber/README.md): intended to listen for pub/sub messages for image creations and automatically vouch images.
-- [Voucher client](cmd/voucher_client/README.md): an example of a Voucher API client that you can use directly in your CI/CD pipeline or as a basis for your own code.
+- [Voucher Server](cmd/voucher_server/README.md): intended to run in your infrastructure to respond to CI/CD pipeline requests.
+- [Voucher Subscriber](cmd/voucher_subscriber/README.md): a program that accepts image creation pub/sub messages from GCR, and automatically vouches the images referenced in those messages. This program doesn't respond to any client requests.
+- [Voucher Client](cmd/voucher_client/README.md): an example of a Voucher API client that you can use directly in your CI/CD pipeline or as a basis for your own code. The client connects to a Voucher Server.
 
 ## Contributing
 

--- a/cmd/voucher_subscriber/README.md
+++ b/cmd/voucher_subscriber/README.md
@@ -26,7 +26,7 @@ All of the configuration options for the Voucher Subscriber is the same as the [
 
 ## Usage
 
-You can run Voucher in server mode by launching `voucher_subscriber`, using the following syntax:
+You can run Voucher in pub/sub subscriber mode by launching `voucher_subscriber`, using the following syntax:
 
 ```shell
 $ voucher_subscriber [--project <project> --subscription <subscription>]

--- a/cmd/voucher_subscriber/README.md
+++ b/cmd/voucher_subscriber/README.md
@@ -1,0 +1,64 @@
+# Voucher Subscriber
+
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Usage](#usage)
+
+## Installation
+
+Install `voucher_subscriber` by running:
+
+```shell
+$ go get -u github.com/grafeas/voucher/cmd/voucher_subscriber
+```
+
+This will download and install the voucher subscriber binary into `$GOPATH/bin` directory.
+
+## Configuration
+
+See the [Tutorial](TUTORIAL.md) for more thorough setup instructions.
+
+An example configuration file can be found in the [config directory](../../config/config.toml).
+
+The configuration can be written as a toml, json, or yaml file, and you can specify the path to the configuration file using the `-c` flag.
+
+All of the configuration options for the Voucher Subscriber is the same as the [Voucher Server](../voucher_server/README.md#configuration)
+
+## Usage
+
+You can run Voucher in server mode by launching `voucher_subscriber`, using the following syntax:
+
+```shell
+$ voucher_subscriber [--project <project> --subscription <subscription>]
+```
+
+`voucher_subscriber` supports the following flags:
+
+| Flag        | Short Flag       | Description                                                                |
+| :--------   | :--------------- | :------------------------------------------------------------------------- |
+| `--project`  | `-p`            | The GCP project to be used.                                                |
+| `--subscription` | `-s`        | The subscription that contains messages.                                   |
+| `--timeout` |                  | The number of seconds to spend checking an image, before failing.          |
+
+For example:
+
+```shell
+$ voucher_subscriber --project my-project --subscription my-subscription
+```
+
+This would launch the subscriber listening to `my-subscription` in `my-project`.
+
+The subscriber expects messages with the following format:
+
+```json
+{
+  "action":"INSERT",
+  "digest":"gcr.io/my-project/hello-world@sha256:6ec128e26cd5...",
+  "tag":"gcr.io/my-project/hello-world:1.1"
+}
+```
+The `tag` field can be omitted but the `action` and `digest` fields are required.
+
+The subscriber currently retries when it can't connect to a MetaData client or start performing a `CheckSuite`. It will log whenever this does happen.
+
+More details about configuring pub/sub with GCR can be found in the [official documentation](https://cloud.google.com/container-registry/docs/configuring-notifications).

--- a/cmd/voucher_subscriber/main.go
+++ b/cmd/voucher_subscriber/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func main() {
+	subscriberCmd.Version = version
+
+	if err := subscriberCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/voucher_subscriber/subscriber.go
+++ b/cmd/voucher_subscriber/subscriber.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/grafeas/voucher/cmd/config"
+	"github.com/grafeas/voucher/subscriber"
+)
+
+var subscriberCmd = &cobra.Command{
+	Use:   "subscriber",
+	Short: "Runs the subscriber",
+	Long: `Run the go subscriber that automatically vouches for images on the specified subscription and project
+	use --project=<project> --subscription=<subscription> to specify the project and subscription you want the subscriber to pull from`,
+	Run: func(cmd *cobra.Command, args []string) {
+		var log = &logrus.Logger{
+			Out:       os.Stderr,
+			Formatter: new(logrus.JSONFormatter),
+			Hooks:     make(logrus.LevelHooks),
+			Level:     logrus.DebugLevel,
+		}
+
+		secrets, err := config.ReadSecrets()
+		if err != nil {
+			log.Errorf("error loading EJSON file, no secrets loaded: %s", err)
+		}
+
+		metricsClient, err := config.MetricsClient()
+		if err != nil {
+			log.Errorf("error configuring metrics client: %s", err)
+		}
+
+		config.RegisterDynamicChecks()
+
+		subscriberConfig := subscriber.Config{
+			Project:        viper.GetString("pubsub.project"),
+			Subscription:   viper.GetString("pubsub.subscription"),
+			RequiredChecks: config.GetRequiredChecksFromConfig()["all"],
+			DryRun:         viper.GetBool("dryrun"),
+			Timeout:        viper.GetInt("pubsub.timeout"),
+		}
+		voucherSubscriber := subscriber.NewSubscriber(&subscriberConfig, secrets, metricsClient, log)
+
+		err = voucherSubscriber.Subscribe(context.Background())
+		if err != nil {
+			log.Errorf("couldn't pull pub/sub messages: %s", err)
+		}
+	},
+}
+
+func init() {
+	cobra.OnInitialize(config.InitConfig)
+
+	subscriberCmd.Flags().StringP("project", "p", "", "pub/sub project that has the subsciprion (required)")
+	subscriberCmd.MarkFlagRequired("project")
+	viper.BindPFlag("pubsub.project", subscriberCmd.Flags().Lookup("project"))
+	subscriberCmd.Flags().StringP("subscription", "s", "", "pub/sub topic subscription (required)")
+	subscriberCmd.MarkFlagRequired("subscription")
+	viper.BindPFlag("pubsub.subscription", subscriberCmd.Flags().Lookup("subscription"))
+	subscriberCmd.Flags().StringVarP(&config.FileName, "config", "c", "", "path to config")
+	subscriberCmd.Flags().IntP("timeout", "", 240, "number of seconds that should be dedicated to a Voucher call")
+	viper.BindPFlag("pubsub.timeout", subscriberCmd.Flags().Lookup("timeout"))
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go v0.52.0
+	cloud.google.com/go/pubsub v1.0.1
 	github.com/DataDog/datadog-go v3.4.0+incompatible
 	github.com/Shopify/ejson v1.2.0
 	github.com/antihax/optional v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ cloud.google.com/go v0.52.0 h1:GGslhk/BU052LPlnI1vpp3fcbUs+hQ3E+Doti/3/vF8=
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
+cloud.google.com/go/pubsub v1.0.1 h1:W9tAK3E57P75u0XLLR82LZyw8VpAnhmyTOxW9qzmyj8=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -290,6 +291,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/metrics/dogstatsd.go
+++ b/metrics/dogstatsd.go
@@ -61,6 +61,16 @@ func (d *DogStatsdClient) CheckAttestationError(check string, err error) {
 	_ = d.client.Event(createDataDogErrorEvent(check, "Voucher Check Attestation Error", err))
 }
 
+// PubSubMessageReceived tracks the number of messages received from pub/sub
+func (d *DogStatsdClient) PubSubMessageReceived() {
+	_ = d.client.Incr("auto_voucher.message.received", []string{}, d.samplingRate)
+}
+
+// PubSubTotalLatency tracks the time it takes to process a pub/sub message
+func (d *DogStatsdClient) PubSubTotalLatency(duration time.Duration) {
+	_ = d.client.Timing("auto_voucher.latency", duration, []string{}, d.samplingRate)
+}
+
 func createDataDogErrorEvent(check, title string, err error) *statsd.Event {
 	event := statsd.NewEvent(title, err.Error())
 	event.AlertType = statsd.Error

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -14,4 +14,6 @@ type Client interface {
 	CheckAttestationStart(string)
 	CheckAttestationError(string, error)
 	CheckAttestationSuccess(string)
+	PubSubMessageReceived()
+	PubSubTotalLatency(time.Duration)
 }

--- a/metrics/noop_client.go
+++ b/metrics/noop_client.go
@@ -15,3 +15,5 @@ func (*NoopClient) CheckRunSuccess(string)                        {}
 func (*NoopClient) CheckAttestationStart(string)                  {}
 func (*NoopClient) CheckAttestationError(string, error)           {}
 func (*NoopClient) CheckAttestationSuccess(string)                {}
+func (*NoopClient) PubSubMessageReceived()                        {}
+func (*NoopClient) PubSubTotalLatency(time.Duration)              {}

--- a/subscriber/check.go
+++ b/subscriber/check.go
@@ -1,0 +1,59 @@
+package subscriber
+
+import (
+	"context"
+
+	"github.com/docker/distribution/reference"
+	"github.com/grafeas/voucher"
+	"github.com/grafeas/voucher/cmd/config"
+	"github.com/grafeas/voucher/repository"
+)
+
+// check runs all checks for a given image.
+// Returns true if the required check(s) have passed and true if the check run needs to be retried.
+func (s *Subscriber) check(canonicalImageReference reference.Canonical) (bool, bool) {
+	var repositoryClient repository.Client
+	var err error
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.cfg.TimeoutDuration())
+	defer cancel()
+
+	metadataClient, err := config.NewMetadataClient(ctx, s.secrets)
+	if nil != err {
+		s.log.Errorf("failed to create MetadataClient: %s", err)
+		return false, true
+	}
+	defer metadataClient.Close()
+
+	buildDetail, err := metadataClient.GetBuildDetail(ctx, canonicalImageReference)
+	if nil != err {
+		s.log.Warningf("could not get image metadata for %s: %s", canonicalImageReference, err)
+	} else {
+		if s.secrets != nil {
+			repositoryClient, err = config.NewRepositoryClient(ctx, s.secrets.RepositoryAuthentication, buildDetail.RepositoryURL)
+			if nil != err {
+				s.log.Warningf("failed to create repository client, continuing without git repo support: %s", err)
+			}
+		} else {
+			s.log.Warning("failed to create repository client, no secrets configured")
+		}
+	}
+
+	checksuite, err := config.NewCheckSuite(s.secrets, metadataClient, repositoryClient, s.cfg.RequiredChecks...)
+	if nil != err {
+		s.log.Errorf("failed to create CheckSuite: %s", err)
+		return false, true
+	}
+
+	var results []voucher.CheckResult
+
+	if s.cfg.DryRun {
+		results = checksuite.Run(ctx, s.metrics, canonicalImageReference)
+	} else {
+		results = checksuite.RunAndAttest(ctx, metadataClient, s.metrics, canonicalImageReference)
+	}
+
+	checkResponse := voucher.NewResponse(canonicalImageReference, results)
+
+	return checkResponse.Success, false
+}

--- a/subscriber/config.go
+++ b/subscriber/config.go
@@ -1,0 +1,22 @@
+package subscriber
+
+import (
+	"time"
+
+	"github.com/grafeas/voucher/server"
+)
+
+// Config stores the necessary details for a Subscriber
+type Config struct {
+	Server         *server.Server
+	Project        string
+	Subscription   string
+	RequiredChecks []string
+	DryRun         bool
+	Timeout        int
+}
+
+// TimeoutDuration returns the configured timeout for this Server.
+func (c *Config) TimeoutDuration() time.Duration {
+	return time.Duration(c.Timeout) * time.Second
+}

--- a/subscriber/payload.go
+++ b/subscriber/payload.go
@@ -10,7 +10,8 @@ import (
 const insertAction string = "INSERT"
 
 var (
-	errInvalidPayload   error = errors.New("ignoring; payload is invalid")
+	errNotInsertAction  error = errors.New("ignoring; not an INSERT action")
+	errNoDigest         error = errors.New("no digest specified")
 	errConversionFailed error = errors.New("error converting reference into type reference.Canonical")
 )
 
@@ -31,13 +32,13 @@ func parsePayload(message []byte) (*Payload, error) {
 	}
 
 	if pl.Action != insertAction {
-		return nil, errInvalidPayload
+		return nil, errNotInsertAction
 	}
 
 	// an image without a digest is only tagged; opt to skip this image
 	// as the digest version has already been pushed and will be processed soon
 	if pl.Digest == "" {
-		return nil, errInvalidPayload
+		return nil, errNoDigest
 	}
 
 	return &pl, nil

--- a/subscriber/payload.go
+++ b/subscriber/payload.go
@@ -1,0 +1,58 @@
+package subscriber
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/docker/distribution/reference"
+)
+
+const insertAction string = "INSERT"
+
+var (
+	errInvalidPayload   error = errors.New("ignoring; payload is invalid")
+	errConversionFailed error = errors.New("error converting reference into type reference.Canonical")
+)
+
+// Payload contains the information from the pub/sub message
+type Payload struct {
+	Action string `json:"action"`
+	Digest string `json:"digest"`
+	Tag    string `json:"tag,omitempty"`
+}
+
+// parsePayload parses data from a pubsub message.
+func parsePayload(message []byte) (*Payload, error) {
+	var pl Payload
+
+	err := json.Unmarshal(message, &pl)
+	if err != nil {
+		return nil, err
+	}
+
+	if pl.Action != insertAction {
+		return nil, errInvalidPayload
+	}
+
+	// an image without a digest is only tagged; opt to skip this image
+	// as the digest version has already been pushed and will be procssed soon
+	if pl.Digest == "" {
+		return nil, errInvalidPayload
+	}
+
+	return &pl, nil
+}
+
+func (p *Payload) asCanonicalImage() (reference.Canonical, error) {
+	imageRef, err := reference.Parse(p.Digest)
+	if nil != err {
+		return nil, err
+	}
+
+	canonicalRef, ok := imageRef.(reference.Canonical)
+	if !ok {
+		return nil, errConversionFailed
+	}
+
+	return canonicalRef, nil
+}

--- a/subscriber/payload.go
+++ b/subscriber/payload.go
@@ -35,7 +35,7 @@ func parsePayload(message []byte) (*Payload, error) {
 	}
 
 	// an image without a digest is only tagged; opt to skip this image
-	// as the digest version has already been pushed and will be procssed soon
+	// as the digest version has already been pushed and will be processed soon
 	if pl.Digest == "" {
 		return nil, errInvalidPayload
 	}

--- a/subscriber/payload_test.go
+++ b/subscriber/payload_test.go
@@ -17,13 +17,13 @@ var payloadTestCases = []struct {
 	{
 		"returns nil payload with error for non-INSERT action payload",
 		[]byte(`{ "action":"DELETE" }`),
-		errInvalidPayload,
+		errNotInsertAction,
 		nil,
 	},
 	{
 		"returns an error when INSERT payload has no digest",
 		[]byte(`{ "action":"INSERT" }`),
-		errInvalidPayload,
+		errNoDigest,
 		nil,
 	},
 }

--- a/subscriber/payload_test.go
+++ b/subscriber/payload_test.go
@@ -1,0 +1,45 @@
+package subscriber
+
+import "testing"
+
+var payloadTestCases = []struct {
+	name            string
+	rawPayload      []byte
+	expectedErr     error
+	expectedPayload *Payload
+}{
+	{
+		"successfully parses INSERT payload",
+		[]byte(`{ "action":"INSERT", "digest": "some-digest-we-dont-validate" }`),
+		nil,
+		&Payload{Action: insertAction, Digest: "some-digest-dont-validate"},
+	},
+	{
+		"returns nil payload with error for non-INSERT action payload",
+		[]byte(`{ "action":"DELETE" }`),
+		errInvalidPayload,
+		nil,
+	},
+	{
+		"returns an error when INSERT payload has no digest",
+		[]byte(`{ "action":"INSERT" }`),
+		errInvalidPayload,
+		nil,
+	},
+}
+
+func TestParsePayload(t *testing.T) {
+	for _, tc := range payloadTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pl, err := parsePayload(tc.rawPayload)
+
+			if (pl == nil && tc.expectedPayload != nil) || (pl != nil && tc.expectedPayload == nil) {
+				t.Errorf("unexpected payload: got %v, want %v", pl, tc.expectedPayload)
+			}
+
+			if err != tc.expectedErr {
+				t.Errorf("error: got %v, want %v", err, tc.expectedErr)
+			}
+		})
+	}
+}

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -54,7 +54,7 @@ func (s *Subscriber) Subscribe(ctx context.Context) error {
 
 		pl, err := parsePayload(msg.Data)
 		if err != nil {
-			if err != errInvalidPayload {
+			if err != errNotInsertAction {
 				s.log.WithField("reason", err).WithField("payload", string(msg.Data)).Error("couldn't parse pub/sub payload")
 			}
 

--- a/subscriber/subscriber.go
+++ b/subscriber/subscriber.go
@@ -1,0 +1,97 @@
+package subscriber
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/grafeas/voucher/cmd/config"
+	"github.com/grafeas/voucher/metrics"
+	"github.com/sirupsen/logrus"
+)
+
+// Subscriber contains the information required to pull messages from a pub/sub topic.
+type Subscriber struct {
+	cfg     *Config
+	secrets *config.Secrets
+	metrics metrics.Client
+	log     *logrus.Logger
+}
+
+// NewSubscriber creates a new subscription topic puller for a subscription.
+func NewSubscriber(config *Config, secrets *config.Secrets, metrics metrics.Client, log *logrus.Logger) *Subscriber {
+	return &Subscriber{
+		cfg:     config,
+		secrets: secrets,
+		metrics: metrics,
+		log:     log,
+	}
+}
+
+// Subscribe pulls messages for a subscription and passes them along to get checked.
+func (s *Subscriber) Subscribe(ctx context.Context) error {
+	client, err := pubsub.NewClient(ctx, s.cfg.Project)
+	if err != nil {
+		return fmt.Errorf("failed to create new pubsub client: %s", err)
+	}
+	defer client.Close()
+
+	sub := client.Subscription(s.cfg.Subscription)
+	sub.ReceiveSettings.Synchronous = true
+	sub.ReceiveSettings.MaxOutstandingMessages = 10
+
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	err = sub.Receive(cctx, func(ctx context.Context, msg *pubsub.Message) {
+		processStart := time.Now()
+		defer func(startTime time.Time) {
+			s.metrics.PubSubTotalLatency(time.Since(startTime))
+		}(processStart)
+
+		s.metrics.PubSubMessageReceived()
+
+		pl, err := parsePayload(msg.Data)
+		if err != nil {
+			if err != errInvalidPayload {
+				s.log.WithField("reason", err).WithField("payload", string(msg.Data)).Error("couldn't parse pub/sub payload")
+			}
+
+			msg.Ack()
+			return
+		}
+
+		l := s.log.WithField("payload", pl)
+
+		cir, err := pl.asCanonicalImage()
+		if err != nil {
+			msg.Ack()
+			l.WithField("reason", err).Error("couldn't make canonical image")
+			return
+		}
+
+		l.WithField("status", "pending").Info("the vouch started")
+		vouchStatus, shouldRetry := s.check(cir)
+
+		// Nack if we want to retry, otherwise the catch-all Ack below will
+		// ensure this message doesn't get retried
+		if vouchStatus {
+			l.WithField("status", "success").Info("the vouch succeeded")
+		} else {
+			l.WithField("status", "failure").Info("the vouch failed")
+
+			if shouldRetry {
+				msg.Nack()
+			}
+		}
+
+		msg.Ack()
+	})
+
+	if err != nil {
+		return fmt.Errorf("sub.Receive: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
this new option will allow one to use a GCP pub/sub subscription and automatically
vouch INSERT messages that come in. this works best when used with a subscription that's
subscribed to the default GCR pub/sub topic but will work with any pub/sub subscription that
receives messages of the format:
```json
{
  "action":"INSERT",
  "digest":"gcr.io/my-project/hello-world@sha256:6ec128e26cd5...",
  "tag":"gcr.io/my-project/hello-world:1.1"
}
```

the implementation will:
- re use the existing config file and flags
- add support for pubsub.timeout, pubsub.project, and pubsub.subscription
- push metrics every time a message is received and the total time it takes
to vouch the message
- some basic notion of retries; this can be extended fairly easily!
- re use the logic for how voucher_server handles checks to actually perform
the checks

closes https://github.com/grafeas/voucher/issues/9