### PR TITLE
Makefile: v2 module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,10 @@ on:
     branches: [ main ]
 
 jobs:
-
   build:
     name: Test
     runs-on: ubuntu-latest
     steps:
-
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
@@ -21,9 +19,5 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
-    - name: Get dependencies
-      run: |
-        cd v2 && go get -v -t -d ./...
-
     - name: Test
-      run: cd v2 && go test -v ./...
+      run: make test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,16 +4,19 @@ before:
      - make ensure-deps
 builds:
   - id: voucher_server
+    dir: v2
     main: ./cmd/voucher_server
     binary: voucher_server
     env:
       - CGO_ENABLED=0
   - id: voucher_subscriber
+    dir: v2
     main: ./cmd/voucher_subscriber
     binary: voucher_subscriber
     env:
       - CGO_ENABLED=0
   - id: voucher_client
+    dir: v2
     main: ./cmd/voucher_client
     binary: voucher_client
     env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,15 @@ FROM golang:1.14-alpine as builder
 
 LABEL maintainer "catherinejones"
 WORKDIR /go/src/github.com/grafeas/voucher
-COPY . .
 RUN apk --no-cache add \
     git \
-    make && \
-    make voucher_server
+    make
+COPY Makefile .
+COPY v2/go.mod v2/
+COPY v2/go.sum v2/
+RUN make ensure-deps
+COPY . .
+RUN make voucher_server
 
 # Final build
 FROM alpine:3.12

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 # Go parameters
-GOCMD=go
+GOCMD=cd v2 && go
 GORELEASER=goreleaser
-GOLANGCI-LINT=golangci-lint
+GOLANGCI-LINT=cd v2 && golangci-lint
 DOCKER=docker
 GOPATH?=`echo $$GOPATH`
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 PACKAGES := voucher_server voucher_subscriber voucher_client
-CODE=./v2/cmd/
+CODE=./cmd/
 SERVER_NAME=voucher_server
 SUBSCRIBER_NAME=voucher_subscriber
 CLIENT_NAME=voucher_client
@@ -39,16 +39,16 @@ endif
 	$(info "No missing dependencies")
 
 show-coverage: test
-	go tool cover -html=coverage.txt
+	$(GOCMD) tool cover -html=coverage.txt
 
 test:
-	go test ./... -race -coverprofile=coverage.txt -covermode=atomic
+	$(GOCMD) test ./... -race -coverprofile=coverage.txt -covermode=atomic
 
 lint:
-	golangci-lint run
+	$(GOLANGCI-LINT) run
 
 lint-new:
-	golangci-lint run --new-from-rev master
+	$(GOLANGCI-LINT) run --new-from-rev main
 
 clean:
 	$(GOCLEAN)
@@ -57,7 +57,6 @@ clean:
 	done
 
 ensure-deps:
-	$(GOCMD) mod tidy
 	$(GOCMD) mod download
 	$(GOCMD) mod verify
 
@@ -68,13 +67,13 @@ update-deps:
 build: $(PACKAGES)
 
 voucher_client:
-	$(GOBUILD) -o build/$(CLIENT_NAME) -v $(CODE)$(CLIENT_NAME)
+	$(GOBUILD) -o ../build/$(CLIENT_NAME) -v $(CODE)$(CLIENT_NAME)
 
 voucher_subscriber:
-	$(GOBUILD) -o build/$(SUBSCRIBER_NAME) -v $(CODE)$(SUBSCRIBER_NAME)
+	$(GOBUILD) -o ../build/$(SUBSCRIBER_NAME) -v $(CODE)$(SUBSCRIBER_NAME)
 
 voucher_server:
-	$(GOBUILD) -o build/$(SERVER_NAME) -v $(CODE)$(SERVER_NAME)
+	$(GOBUILD) -o ../build/$(SERVER_NAME) -v $(CODE)$(SERVER_NAME)
 
 container:
 	$(DOCKER) build -t $(IMAGE_NAME) .


### PR DESCRIPTION
* Update the `Makefile` and `goreleaser` configuration to expect the module to be rooted at `v2`.
* Use the `Makefile` in CI, so people [like me](https://github.com/grafeas/voucher/pull/30) stop breaking it :trollface: 
* Optimize the Dockerfile steps to maximize layer cache hits (assumption: `go.mod` changes are less likely than code changes)

To test this, you'll want to use the `make` targets, and `goreleaser release --skip-publish`. The latter may need `--skip-validations`.

# Related
- Fixes regression from https://github.com/grafeas/voucher/pull/30
- Echoes https://github.com/grafeas/voucher/pull/29