### PR TITLE
go fmt

### DIFF
--- a/v2/clair/clair.go
+++ b/v2/clair/clair.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"net/http"
 
-	s1 "github.com/grafeas/voucher/v2/docker/schema1"
-	s2 "github.com/grafeas/voucher/v2/docker/schema2"
 	v1 "github.com/coreos/clair/api/v1"
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/reference"
+	s1 "github.com/grafeas/voucher/v2/docker/schema1"
+	s2 "github.com/grafeas/voucher/v2/docker/schema2"
 	digest "github.com/opencontainers/go-digest"
 	"golang.org/x/oauth2"
 )

--- a/v2/grafeas/client_test.go
+++ b/v2/grafeas/client_test.go
@@ -342,10 +342,10 @@ func createAllOccurrences() []objects.Occurrence {
 		{Name: "name1", Resource: &objects.Resource{URI: "https://gcr.io/project/image@sha256:foo"},
 			NoteName: "notename", Kind: &noteKindVuln,
 			Vulnerability: &objects.VulnerabilityDetails{Type: "vulnmedium", Severity: &vulnSeverity,
-			    EffectiveSeverity: &vulnEffectiveSeverity,
-					PackageIssue: []objects.VulnerabilityPackageIssue{{
-						AffectedLocation: &objects.VulnerabilityLocation{CpeURI: "uri", Package: "package_test",
-							Version: &objects.PackageVersion{Name: "v0.0.0", Kind: &packageKind, Revision: "r"}}}}}},
+				EffectiveSeverity: &vulnEffectiveSeverity,
+				PackageIssue: []objects.VulnerabilityPackageIssue{{
+					AffectedLocation: &objects.VulnerabilityLocation{CpeURI: "uri", Package: "package_test",
+						Version: &objects.PackageVersion{Name: "v0.0.0", Kind: &packageKind, Revision: "r"}}}}}},
 
 		{Name: "name2", Resource: &objects.Resource{URI: "https://gcr.io/project/image@sha256:foo"},
 			NoteName: "notename", Kind: &noteKindAtt,

--- a/v2/signer/kms/signer.go
+++ b/v2/signer/kms/signer.go
@@ -82,7 +82,7 @@ func (s *Signer) Sign(checkName, body string) (string, string, error) {
 	}
 
 	resp, err := s.client.AsymmetricSign(context.Background(), &kms_pb.AsymmetricSignRequest{
-		Name: key.Path,
+		Name:   key.Path,
 		Digest: &d,
 	})
 


### PR DESCRIPTION
This is an automated reformat via `go fmt` of some files that slipped out of compliance.

Invoking `golanglint-ci` configuration from the GitHub Actions workflow would prevent regressions, but need a little more (manual) cleanup before the latest version could be enabled:
```
$ golangci-lint version && echo && golangci-lint run
golangci-lint has version 1.42.0 built from c6142e3 on 2021-08-17T08:27:57Z

WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
auth/error.go:10:6: type name will be used as auth.AuthError by other packages, and that stutters; consider calling this Error (golint)
type AuthError struct {
     ^
cmd/voucher_subscriber/subscriber.go:60:32: Error return value of `subscriberCmd.MarkFlagRequired` is not checked (errcheck)
	subscriberCmd.MarkFlagRequired("project")
	                              ^
cmd/voucher_subscriber/subscriber.go:63:32: Error return value of `subscriberCmd.MarkFlagRequired` is not checked (errcheck)
	subscriberCmd.MarkFlagRequired("subscription")
	                              ^
subscriber/subscriber.go:55:7: shadow: declaration of "err" shadows declaration at line 34 (govet)
		pl, err := parsePayload(msg.Data)
		    ^
```

I wasn't sure if that was worth it, but the `go fmt` patch is basically free.