### PR TITLE
Golangci lint actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,15 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: 1.14
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
     - name: Test
       run: make test
+
+    - name: Lint
+      uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
+      with:
+        working-directory: v2/

--- a/v2/auth/error.go
+++ b/v2/auth/error.go
@@ -6,18 +6,18 @@ import (
 	"github.com/docker/distribution/reference"
 )
 
-// AuthError is the error returned when authenticating while pulling manifests connecting to protected systems
-type AuthError struct {
+// Error is the error returned when authenticating while pulling manifests connecting to protected systems
+type Error struct {
 	Reason    string
 	ImageName reference.Named
 }
 
 // Error returns a string for logging purposes
-func (e *AuthError) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("auth failed: %s for %s", e.Reason, e.ImageName)
 }
 
 // NewAuthError returns an AuthError struct with the reason for erroring, as well as the Name of the image reference
 func NewAuthError(reason string, imageName reference.Named) error {
-	return &AuthError{reason, imageName}
+	return &Error{reason, imageName}
 }

--- a/v2/cmd/voucher_subscriber/subscriber.go
+++ b/v2/cmd/voucher_subscriber/subscriber.go
@@ -57,10 +57,10 @@ func init() {
 	cobra.OnInitialize(config.InitConfig)
 
 	subscriberCmd.Flags().StringP("project", "p", "", "pub/sub project that has the subsciprion (required)")
-	subscriberCmd.MarkFlagRequired("project")
+	_ = subscriberCmd.MarkFlagRequired("project")
 	viper.BindPFlag("pubsub.project", subscriberCmd.Flags().Lookup("project"))
 	subscriberCmd.Flags().StringP("subscription", "s", "", "pub/sub topic subscription (required)")
-	subscriberCmd.MarkFlagRequired("subscription")
+	_ = subscriberCmd.MarkFlagRequired("subscription")
 	viper.BindPFlag("pubsub.subscription", subscriberCmd.Flags().Lookup("subscription"))
 	subscriberCmd.Flags().StringVarP(&config.FileName, "config", "c", "", "path to config")
 	subscriberCmd.Flags().IntP("timeout", "", 240, "number of seconds that should be dedicated to a Voucher call")

--- a/v2/subscriber/subscriber.go
+++ b/v2/subscriber/subscriber.go
@@ -44,7 +44,7 @@ func (s *Subscriber) Subscribe(ctx context.Context) error {
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	err = sub.Receive(cctx, func(ctx context.Context, msg *pubsub.Message) {
+	msgErr := sub.Receive(cctx, func(ctx context.Context, msg *pubsub.Message) {
 		processStart := time.Now()
 		defer func(startTime time.Time) {
 			s.metrics.PubSubTotalLatency(time.Since(startTime))
@@ -89,8 +89,8 @@ func (s *Subscriber) Subscribe(ctx context.Context) error {
 		msg.Ack()
 	})
 
-	if err != nil {
-		return fmt.Errorf("sub.Receive: %s", err)
+	if msgErr != nil {
+		return fmt.Errorf("sub.Receive: %s", msgErr)
 	}
 
 	return nil


### PR DESCRIPTION
Enable golangci-lint in GitHub actions, so that formatting is verified in incoming PRs.

~When opened, I expect this PR to be rejected due to `auth.AuthError` - I'll address that after verifying it fails as expected 🤞 .~ This failure happened, as expected.

Closes https://github.com/grafeas/voucher/issues/36