### PR TITLE
golang-1.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.14
+        go-version: 1.16
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM golang:1.14-alpine as builder
+FROM golang:1.16-alpine as builder
 
 LABEL maintainer "catherinejones"
 WORKDIR /go/src/github.com/grafeas/voucher

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafeas/voucher/v2
 
-go 1.13
+go 1.16
 
 require (
 	cloud.google.com/go v0.52.0

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/gorilla/mux v1.6.2
-	github.com/iancoleman/strcase v0.2.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mennanov/fieldmask-utils v0.0.0-20190703161732-eca3212cf9f3
 	github.com/mitchellh/go-homedir v1.1.0

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -16,10 +16,10 @@ require (
 	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
 	github.com/fernet/fernet-go v0.0.0-20180830025343-9eac43b88a5e // indirect
 	github.com/golang/mock v1.4.4
-	github.com/golang/protobuf v1.4.1
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5
 	github.com/gorilla/mux v1.6.2
+	github.com/iancoleman/strcase v0.2.0
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mennanov/fieldmask-utils v0.0.0-20190703161732-eca3212cf9f3
 	github.com/mitchellh/go-homedir v1.1.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -236,6 +236,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphqk3QUflDy9QdksZR4ygR807bpy0=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -14,7 +14,6 @@ cloud.google.com/go/datastore v1.0.0 h1:Kt+gOPPp2LEPWp8CSfxhsM8ik9CcyE/gYu+0r+Rn
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/pubsub v1.0.1 h1:W9tAK3E57P75u0XLLR82LZyw8VpAnhmyTOxW9qzmyj8=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
-cloud.google.com/go/storage v1.0.0 h1:VV2nUM3wwLLGh9lSABFgZMjInyUbJeaRSE64WuAIQ+4=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRqYosuDstRB9un7SOx2k/9ckA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -179,7 +178,6 @@ github.com/google/go-github/v29 v29.0.2 h1:opYN6Wc7DOz7Ku3Oh4l7prmkOMwEcQxpFtxdU
 github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -198,7 +196,6 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408 h1:Y9iQJfEqnN3/Nce9cOegemcy/9Ai5k3huT6E80F3zaw=
 github.com/goware/prefixer v0.0.0-20160118172347-395022866408/go.mod h1:PE1ycukgRPJ7bJ9a1fdfQ9j8i/cEcRAoLZzbxYpNB/s=
@@ -586,7 +583,6 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20210107172259-749611fa9fcc h1:XANm4xAMEQhRdWKqaL0qmhGDv7RuobwCO97TIlktaQE=
 gopkg.in/yaml.v3 v3.0.0-20210107172259-749611fa9fcc/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -236,8 +236,6 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphqk3QUflDy9QdksZR4ygR807bpy0=
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
-github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/v2/repository/github/queries_test.go
+++ b/v2/repository/github/queries_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/protobuf/protoc-gen-go/generator"
+	"github.com/iancoleman/strcase"
 	utils "github.com/mennanov/fieldmask-utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,7 +14,7 @@ type queryHandlerFunc func(query interface{}, variables map[string]interface{}) 
 
 func createHandler(input interface{}, mask []string) queryHandlerFunc {
 	return func(query interface{}, variables map[string]interface{}) error {
-		mask, err := utils.MaskFromPaths(mask, generator.CamelCase)
+		mask, err := utils.MaskFromPaths(mask, strcase.ToCamel)
 		if err != nil {
 			return err
 		}

--- a/v2/repository/github/queries_test.go
+++ b/v2/repository/github/queries_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/iancoleman/strcase"
 	utils "github.com/mennanov/fieldmask-utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -14,7 +13,7 @@ type queryHandlerFunc func(query interface{}, variables map[string]interface{}) 
 
 func createHandler(input interface{}, mask []string) queryHandlerFunc {
 	return func(query interface{}, variables map[string]interface{}) error {
-		mask, err := utils.MaskFromPaths(mask, strcase.ToCamel)
+		mask, err := utils.MaskFromPaths(mask, func(s string) string { return s })
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Update actions and Dockerfile to prefer `go1.16`.

In https://github.com/grafeas/voucher/pull/38/files#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R17 , I removed a leading carat that meant tests looked like they were being run with `go1.14`, when really `go1.16.7` was being used: https://github.com/grafeas/voucher/runs/3505266908?check_suite_focus=true#step:2:10

Actually using `go1.14` for testing [breaks tests, which rely on `t.TempDir()`](https://github.com/grafeas/voucher/runs/3543992057?check_suite_focus=true#step:4:129) - which was [added in `go1.15`](https://golang.org/doc/go1.15#testing) 🤦 

So this PR uses `go1.16` in earnest, instead of relying on `actions/setup-go`'s behaviour.

---

There's [_another_ lint issue that snuck through](https://github.com/grafeas/voucher/runs/3545756267#step:5:68):
```
 Error: SA1019: package github.com/golang/protobuf/protoc-gen-go/generator is deprecated: Use the "google.golang.org/protobuf/compiler/protogen" package instead to write protoc plugins in Go.  (staticcheck)
```

Here, all we were using is the `CamelCase()` conversion function - I couldn't find it in the "new" library,  so I've replaced the call with a purpose-built library. I didn't vet the library beyond confirming it has a compatible license and reading https://github.com/iancoleman/strcase/blob/master/camel.go