### PR TITLE
ci: extend linter timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,6 @@ jobs:
       uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
       with:
         working-directory: v2/
+        args: --timeout 3m
+        skip-pkg-cache: true
+        skip-build-cache: true


### PR DESCRIPTION
Give the `golangci-lint` action a 300% longer timeout, because [it sometimes times out](https://github.com/grafeas/voucher/runs/3598378905?check_suite_focus=true#step:5:24303).

Tell the `golangci-lint` action not to worry about the cache, since the preceding `go build` step populates everything this cache would restore - it just wastes time and spams `File exists`.