### PR TITLE
Change Voucher Client server configuration to avoid conflict with environment variables

### DIFF
--- a/v2/cmd/voucher_client/README.md
+++ b/v2/cmd/voucher_client/README.md
@@ -22,7 +22,7 @@ Below are the configuration options for Voucher Client:
 
 | Key         | Description                                                                                |
 | :---------- | :----------------------------------------------------------------------------------------- |
-| `hostname`  | The Voucher server to connect to.                                                          |
+| `server`  | The Voucher server to connect to.                                                          |
 | `timeout`   | The number of seconds to wait before failing (defaults to 240).                            |
 | `username`  | Username to authenticate against Voucher with.                                             |
 | `password`  | Password to authenticate against Voucher with.                                             |
@@ -33,7 +33,7 @@ Configuration options can be overridden at runtime by setting the appropriate fl
 
 ```yaml
 ---
-hostname: "https://my-voucher-server"
+server: "https://my-voucher-server"
 username: "<username>"
 password: "<password>"
 ```

--- a/v2/cmd/voucher_client/README.md
+++ b/v2/cmd/voucher_client/README.md
@@ -22,7 +22,7 @@ Below are the configuration options for Voucher Client:
 
 | Key         | Description                                                                                |
 | :---------- | :----------------------------------------------------------------------------------------- |
-| `server`  | The Voucher server to connect to.                                                          |
+| `server`    | The Voucher server to connect to.                                                          |
 | `timeout`   | The number of seconds to wait before failing (defaults to 240).                            |
 | `username`  | Username to authenticate against Voucher with.                                             |
 | `password`  | Password to authenticate against Voucher with.                                             |

--- a/v2/cmd/voucher_client/config.go
+++ b/v2/cmd/voucher_client/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 type config struct {
-	Hostname string
+	Server   string
 	Username string
 	Password string
 	Timeout  int
@@ -23,7 +23,7 @@ func getCheck() string {
 }
 
 func getVoucherClient() (voucher.Interface, error) {
-	newClient, err := client.NewClient(defaultConfig.Hostname)
+	newClient, err := client.NewClient(defaultConfig.Server)
 	if nil == err {
 		newClient.SetBasicAuth(defaultConfig.Username, defaultConfig.Password)
 	}

--- a/v2/cmd/voucher_client/root.go
+++ b/v2/cmd/voucher_client/root.go
@@ -43,8 +43,8 @@ func init() {
 
 	rootCmd.Flags().BoolVar(&verify, "verify", false, "Verify instead of check an image.")
 	rootCmd.Flags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.voucher.yaml)")
-	rootCmd.Flags().StringVarP(&defaultConfig.Hostname, "voucher", "v", "http://localhost:8000", "Voucher server to connect to.")
-	viper.BindPFlag("hostname", rootCmd.Flags().Lookup("voucher"))
+	rootCmd.Flags().StringVarP(&defaultConfig.Server, "voucher", "v", "http://localhost:8000", "Voucher server to connect to.")
+	viper.BindPFlag("server", rootCmd.Flags().Lookup("voucher"))
 	rootCmd.Flags().StringVar(&defaultConfig.Username, "username", "", "Username to authenticate against Voucher with")
 	viper.BindPFlag("username", rootCmd.Flags().Lookup("username"))
 	rootCmd.Flags().StringVar(&defaultConfig.Password, "password", "", "Password to authenticate against Voucher with")


### PR DESCRIPTION
In some alpine images, when calling voucher_client from a container. The hostname would be overridden by an environment variable present in the OS causing voucher_client to make a call to the wrong endpoint.

This pr aims to rename that configuration variable so we won't run into that issue 