### PR TITLE
Bodyclose linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,6 +117,7 @@ linters:
     - gofmt
     - whitespace
     - unparam
+    - bodyclose
   fast: false
 
 

--- a/v2/docker/digest.go
+++ b/v2/docker/digest.go
@@ -30,7 +30,6 @@ func GetDigestFromTagged(client *http.Client, image reference.NamedTagged) (dige
 	if err != nil {
 		return blank, err
 	}
-
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
@@ -63,12 +62,11 @@ func GetDigestFromCanonical(client *http.Client, image reference.Canonical) (dig
 	if err != nil {
 		return blank, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
 		return blank, responseToError(resp)
 	}
-
-	_ = resp.Body.Close()
 
 	imageDigest := digest.Digest(resp.Header.Get("Docker-Content-Digest"))
 	if "" == string(imageDigest) {

--- a/v2/docker/schema2/config.go
+++ b/v2/docker/schema2/config.go
@@ -42,7 +42,6 @@ func RequestConfig(client *http.Client, ref reference.Canonical, manifest distri
 	if nil != err {
 		return nil, err
 	}
-
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 300 {

--- a/v2/grafeas/grafeas_service.go
+++ b/v2/grafeas/grafeas_service.go
@@ -142,12 +142,13 @@ func (g *apiServiceImpl) httpCall(urlAddr *url.URL, payload []byte, method strin
 		}
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	statusCode := resp.StatusCode
 	data, err := ioutil.ReadAll(resp.Body)
 	if statusCode != http.StatusOK || err != nil {
 		return nil, NewAPIError(statusCode, urlAddr.Path, method, data)
 	}
-	resp.Body.Close()
 
 	return data, err
 }


### PR DESCRIPTION
Enable the https://github.com/timakin/bodyclose linter, and fix issues it raises.

There are a few missing, and a few that don't happen on error cases.
I did include whitespace changes to have `defer resp.Body.Close()` in the same stanza as `resp, err := ...` while manually reviewing, before realizing "there _must_ be a linter to do this for me".

While this isn't conclusively #20 , unclosed HTTP connections are a common cause of memory issues.