### PR TITLE
Use idtoken for auth with basic as fallback

### DIFF
--- a/v2/cmd/voucher_client/README.md
+++ b/v2/cmd/voucher_client/README.md
@@ -24,8 +24,9 @@ Below are the configuration options for Voucher Client:
 | :---------- | :----------------------------------------------------------------------------------------- |
 | `server`    | The Voucher server to connect to.                                                          |
 | `timeout`   | The number of seconds to wait before failing (defaults to 240).                            |
-| `username`  | Username to authenticate against Voucher with.                                             |
-| `password`  | Password to authenticate against Voucher with.                                             |
+| `username`  | Username to authenticate against Voucher with. (When auth = basic)                         |
+| `password`  | Password to authenticate against Voucher with. (When auth = basic)                         |
+| `auth`      | The method to authicate against Voucher with. (defaults to basic)                          |
 
 Configuration options can be overridden at runtime by setting the appropriate flag. For example, if you set the "port" flag when running `voucher_server`, that value will override whatever is in the configuration.
 
@@ -50,6 +51,7 @@ $ voucher_client [--voucher <server> --verify --check <check to run>] <image pat
 
 | Flag         | Short Flag       | Description                                                                   |
 | :--------    | :--------------- | :---------------------------------------------------------------------------- |
+| `--auth`     | `-a`             | The method to authenticate against Voucher with.
 | `--config`   |                  | The path to your configuration file, (default is $HOME/.voucher.yaml)         |
 | `--check`    | `-c`             | The Check to run on the image ("all" for all checks).                         |
 | `--voucher`  | `-v`             | The Voucher server to connect to.                                             |

--- a/v2/cmd/voucher_client/README.md
+++ b/v2/cmd/voucher_client/README.md
@@ -26,7 +26,7 @@ Below are the configuration options for Voucher Client:
 | `timeout`   | The number of seconds to wait before failing (defaults to 240).                            |
 | `username`  | Username to authenticate against Voucher with. (When auth = basic)                         |
 | `password`  | Password to authenticate against Voucher with. (When auth = basic)                         |
-| `auth`      | The method to authicate against Voucher with. (defaults to basic)                          |
+| `auth`      | The method to authenticate against Voucher with. (defaults to basic)                          |
 
 Configuration options can be overridden at runtime by setting the appropriate flag. For example, if you set the "port" flag when running `voucher_server`, that value will override whatever is in the configuration.
 

--- a/v2/cmd/voucher_client/config.go
+++ b/v2/cmd/voucher_client/config.go
@@ -14,6 +14,7 @@ type config struct {
 	Password string
 	Timeout  int
 	Check    string
+	Auth     string
 }
 
 var defaultConfig = &config{}
@@ -23,15 +24,17 @@ func getCheck() string {
 }
 
 func getVoucherClient() (voucher.Interface, error) {
-	var newClient *client.Client
-	newClient, err := client.NewAuthClient(defaultConfig.Server)
-	if err != nil {
-		newClient, err = client.NewClient(defaultConfig.Server)
+	switch defaultConfig.Auth {
+	case "idtoken":
+		newClient, err := client.NewAuthClient(defaultConfig.Server)
+		return newClient, err
+	default:
+		newClient, err := client.NewClient(defaultConfig.Server)
 		if err == nil {
 			newClient.SetBasicAuth(defaultConfig.Username, defaultConfig.Password)
 		}
+		return newClient, err
 	}
-	return newClient, err
 }
 
 func newContext() (context.Context, context.CancelFunc) {

--- a/v2/cmd/voucher_client/config.go
+++ b/v2/cmd/voucher_client/config.go
@@ -23,9 +23,13 @@ func getCheck() string {
 }
 
 func getVoucherClient() (voucher.Interface, error) {
-	newClient, err := client.NewClient(defaultConfig.Server)
-	if nil == err {
-		newClient.SetBasicAuth(defaultConfig.Username, defaultConfig.Password)
+	var newClient *client.Client
+	newClient, err := client.NewAuthClient(defaultConfig.Server)
+	if err != nil {
+		newClient, err = client.NewClient(defaultConfig.Server)
+		if err == nil {
+			newClient.SetBasicAuth(defaultConfig.Username, defaultConfig.Password)
+		}
 	}
 	return newClient, err
 }

--- a/v2/cmd/voucher_client/config.go
+++ b/v2/cmd/voucher_client/config.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	voucher "github.com/grafeas/voucher/v2"
@@ -24,16 +26,18 @@ func getCheck() string {
 }
 
 func getVoucherClient() (voucher.Interface, error) {
-	switch defaultConfig.Auth {
+	switch strings.ToLower(defaultConfig.Auth) {
 	case "idtoken":
 		newClient, err := client.NewAuthClient(defaultConfig.Server)
 		return newClient, err
-	default:
+	case "basic":
 		newClient, err := client.NewClient(defaultConfig.Server)
 		if err == nil {
 			newClient.SetBasicAuth(defaultConfig.Username, defaultConfig.Password)
 		}
 		return newClient, err
+	default:
+		return nil, fmt.Errorf("invalid auth value: %q", defaultConfig.Auth)
 	}
 }
 

--- a/v2/cmd/voucher_client/root.go
+++ b/v2/cmd/voucher_client/root.go
@@ -53,6 +53,8 @@ func init() {
 	viper.BindPFlag("timeout", rootCmd.Flags().Lookup("timeout"))
 	rootCmd.Flags().StringVarP(&defaultConfig.Check, "check", "c", "all", "the name of the checks to run against Voucher with")
 	viper.BindPFlag("check", rootCmd.Flags().Lookup("check"))
+	rootCmd.Flags().StringVarP(&defaultConfig.Auth, "auth", "a", "basic", "the method to authenticate against Voucher with. Supported types: basic, idtoken")
+	viper.BindPFlag("auth", rootCmd.Flags().Lookup("auth"))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
With https://github.com/grafeas/voucher/pull/48, adding idtoken auth for `voucher_client`. It auth fails, we fallback to basic