### PR TITLE
containeranalysis: close grpcClient

### DIFF
--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 	grafeas "google.golang.org/genproto/googleapis/grafeas/v1"
 
 	voucher "github.com/grafeas/voucher/v2"
@@ -188,18 +189,12 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 
 // NewClient creates a new containeranalysis Grafeas Client.
 func NewClient(ctx context.Context, binauthProject string, keyring signer.AttestationSigner) (*Client, error) {
-	var err error
-
-	caClient, err := containeranalysisapi.NewClient(ctx)
+	grafeasClient, err := grafeasv1.NewClient(ctx, option.WithEndpoint("containeranalysis.googleapis.com:443"), option.WithScopes(containeranalysisapi.DefaultAuthScopes()...))
 	if err != nil {
 		return nil, err
 	}
-	if err := caClient.Close(); err != nil {
-		return nil, err
-	}
-
 	client := &Client{
-		containeranalysis: caClient.GetGrafeasClient(),
+		containeranalysis: grafeasClient,
 		keyring:           keyring,
 		binauthProject:    binauthProject,
 	}

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -194,6 +194,9 @@ func NewClient(ctx context.Context, binauthProject string, keyring signer.Attest
 	if err != nil {
 		return nil, err
 	}
+	if err := caClient.Close(); err != nil {
+		return nil, err
+	}
 
 	client := &Client{
 		containeranalysis: caClient.GetGrafeasClient(),

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -189,6 +189,7 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 
 // NewClient creates a new containeranalysis Grafeas Client.
 func NewClient(ctx context.Context, binauthProject string, keyring signer.AttestationSigner) (*Client, error) {
+	// These options emulate cloud.google.com/go/containeranalysis/apiv1.NewClient
 	grafeasClient, err := grafeasv1.NewClient(ctx, option.WithEndpoint("containeranalysis.googleapis.com:443"), option.WithScopes(containeranalysisapi.DefaultAuthScopes()...))
 	if err != nil {
 		return nil, err

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,6 +3,7 @@ module github.com/grafeas/voucher/v2
 go 1.16
 
 require (
+	// if updating containeranalysis or grafeas, ensure the options in containeranalysis/client.go are still valid
 	cloud.google.com/go/containeranalysis v0.1.0
 	cloud.google.com/go/grafeas v0.1.0
 	cloud.google.com/go/kms v1.0.0


### PR DESCRIPTION
In `containeranalysis.NewClient()`, we allocate a containeranalysis
client, but only use the `.GetGrafeasClient()` member.

This results in leaking the containeranalysis client's connection pool,
whenever a new client is created.

Longer term, we should look at reusing connections as an alternative
solution to this leak: there are other performance advantages.

Co-Authored-By: Brian Chen <brian.chen@shopify.com>
Co-Authored-By: Aline Shulzhenko <lynnsh@users.noreply.github.com>

# Related
- Reference https://github.com/googleapis/google-cloud-go/blob/containeranalysis/v0.1.0/containeranalysis/apiv1/container_analysis_client.go#L92
- https://github.com/grafeas/voucher/issues/20