### PR TITLE
voucher-client: send User-Agent

### DIFF
--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -24,7 +24,10 @@ type Client struct {
 	httpClient *http.Client
 	username   string
 	password   string
+	userAgent  string
 }
+
+const DefaultUserAgent = "voucher-client/2"
 
 // NewClient creates a new Client set to connect to the passed
 // hostname.
@@ -48,6 +51,11 @@ func (c *Client) SetBasicAuth(username, password string) {
 	c.password = password
 }
 
+// SetUserAgent customizes the user agent used by the client
+func (c *Client) SetUserAgent(userAgent string) {
+	c.userAgent = userAgent
+}
+
 // CopyURL returns a copy of this client's URL
 func (c *Client) CopyURL() *url.URL {
 	urlCopy := (*c.url)
@@ -68,6 +76,9 @@ func (c *Client) newVoucherRequest(ctx context.Context, url string, image refere
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
 	if c.username != "" && c.password != "" {
 		req.SetBasicAuth(c.username, c.password)
 	}
@@ -116,6 +127,7 @@ func newClient(voucherURL string, httpClient *http.Client) (*Client, error) {
 	client := &Client{
 		url:        u,
 		httpClient: httpClient,
+		userAgent:  DefaultUserAgent,
 	}
 	return client, nil
 }

--- a/v2/client/client_test.go
+++ b/v2/client/client_test.go
@@ -38,7 +38,7 @@ func TestNewClient(t *testing.T) {
 		t.Run(label, func(t *testing.T) {
 			c, err := client.NewClient(tc.input)
 			if tc.errMsg != "" {
-				assert.Equal(t, tc.errMsg, err.Error())
+				assert.EqualError(t, err, tc.errMsg)
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tc.hostname, c.CopyURL().String())
@@ -50,7 +50,7 @@ func TestNewClient(t *testing.T) {
 const image = "gcr.io/project/image@sha256:0000000000000000000000000000000000000000000000000000000000000000"
 
 func TestVoucher_Check(t *testing.T) {
-	v := &mockVoucher{}
+	v := &mockVoucher{t: t}
 	v.checks = append(v.checks, &voucher.Response{Image: image, Success: true})
 	srv := httptest.NewServer(v)
 	defer srv.Close()
@@ -62,8 +62,24 @@ func TestVoucher_Check(t *testing.T) {
 	assert.True(t, res.Success)
 }
 
+func TestVoucher_CustomUserAgent(t *testing.T) {
+	const customUserAgent = "my-awesome-voucher/1.0"
+	v := &mockVoucher{t: t}
+	v.ua = customUserAgent
+	v.checks = append(v.checks, &voucher.Response{Image: image, Success: true})
+	srv := httptest.NewServer(v)
+	defer srv.Close()
+
+	c, err := client.NewClient(srv.URL)
+	c.SetUserAgent(customUserAgent)
+	require.NoError(t, err)
+	res, err := c.Check(context.Background(), "diy", canonical(t, image))
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+}
+
 func TestVoucher_Verify(t *testing.T) {
-	v := &mockVoucher{}
+	v := &mockVoucher{t: t}
 	v.verifications = append(v.verifications, &voucher.Response{Image: image, Success: true})
 	srv := httptest.NewServer(v)
 	defer srv.Close()
@@ -76,11 +92,21 @@ func TestVoucher_Verify(t *testing.T) {
 }
 
 type mockVoucher struct {
+	t             *testing.T
+	ua            string
 	checks        []*voucher.Response
 	verifications []*voucher.Response
 }
 
 func (v *mockVoucher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	hdr := r.Header
+	assert.Equal(v.t, "application/json", hdr.Get("Content-Type"))
+	if v.ua != "" {
+		assert.Equal(v.t, v.ua, hdr.Get("User-Agent"))
+	} else {
+		assert.Equal(v.t, client.DefaultUserAgent, hdr.Get("User-Agent"))
+	}
+
 	var req voucher.Request
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "", http.StatusBadRequest)

--- a/v2/cmd/voucher_client/config.go
+++ b/v2/cmd/voucher_client/config.go
@@ -26,19 +26,27 @@ func getCheck() string {
 }
 
 func getVoucherClient() (voucher.Interface, error) {
+	var newClient *client.Client
 	switch strings.ToLower(defaultConfig.Auth) {
 	case "idtoken":
-		newClient, err := client.NewAuthClient(defaultConfig.Server)
-		return newClient, err
-	case "basic":
-		newClient, err := client.NewClient(defaultConfig.Server)
-		if err == nil {
-			newClient.SetBasicAuth(defaultConfig.Username, defaultConfig.Password)
+		var err error
+		newClient, err = client.NewAuthClient(defaultConfig.Server)
+		if err != nil {
+			return nil, err
 		}
-		return newClient, err
+	case "basic":
+		var err error
+		newClient, err = client.NewClient(defaultConfig.Server)
+		if err != nil {
+			return nil, err
+		}
+		newClient.SetBasicAuth(defaultConfig.Username, defaultConfig.Password)
 	default:
 		return nil, fmt.Errorf("invalid auth value: %q", defaultConfig.Auth)
 	}
+
+	newClient.SetUserAgent(fmt.Sprintf("voucher-client/%s", version))
+	return newClient, nil
 }
 
 func newContext() (context.Context, context.CancelFunc) {


### PR DESCRIPTION
Modify the voucher client to send a customizable `User-Agent` header. This is easily spoofed, but helps a `voucher-server` to understand the distribution of its clients.

When voucher client is included as a library, the string `voucher-client/2` is used. There's a method for clients to customize (e.g. `my-awesome-builder/1.0`).
When `voucher_client` is used as a binary, the tagged version (e.g. `voucher-client/2.6.2`) is used.



# Related
- Ref https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent