### PR TITLE
Add support for ADC using voucher_client

### DIFF
--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -42,6 +42,12 @@ func NewAuthClient(voucherURL string) (*Client, error) {
 	return newClient(voucherURL, authClient)
 }
 
+// NewCustomClient creates a new Client set to connect to passed
+// hostname using a passed http client
+func NewCustomClient(voucherURL string, client *http.Client) (*Client, error) {
+	return newClient(voucherURL, client)
+}
+
 // SetBasicAuth adds the username and password to the Client struct
 func (c *Client) SetBasicAuth(username, password string) {
 	c.username = username

--- a/v2/cmd/voucher_client/README.md
+++ b/v2/cmd/voucher_client/README.md
@@ -20,13 +20,13 @@ The configuration for Voucher Client can be written as a toml, json, or yaml fil
 
 Below are the configuration options for Voucher Client:
 
-| Key         | Description                                                                                |
-| :---------- | :----------------------------------------------------------------------------------------- |
-| `server`    | The Voucher server to connect to.                                                          |
-| `timeout`   | The number of seconds to wait before failing (defaults to 240).                            |
-| `username`  | Username to authenticate against Voucher with. (When auth = basic)                         |
-| `password`  | Password to authenticate against Voucher with. (When auth = basic)                         |
-| `auth`      | The method to authenticate against Voucher with. (defaults to basic)                          |
+| Key         | Description                                                                                                                     |
+| :---------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| `server`    | The Voucher server to connect to.                                                                                               |
+| `timeout`   | The number of seconds to wait before failing (defaults to 240).                                                                 |
+| `username`  | Username to authenticate against Voucher with. (When auth = basic)                                                              |
+| `password`  | Password to authenticate against Voucher with. (When auth = basic)                                                              |
+| `auth`      | The method to authenticate against Voucher with. (defaults to basic). Possible values: basic, idtoken, default-access-token     |
 
 Configuration options can be overridden at runtime by setting the appropriate flag. For example, if you set the "port" flag when running `voucher_server`, that value will override whatever is in the configuration.
 

--- a/v2/cmd/voucher_client/config.go
+++ b/v2/cmd/voucher_client/config.go
@@ -37,7 +37,7 @@ func getVoucherClient() (voucher.Interface, error) {
 		}
 		return newClient, err
 	case "default-access-token":
-		newClient, err := NewAuthClientWithToken(defaultConfig.Server)
+		newClient, err := NewAuthClientWithToken(context.Background(), defaultConfig.Server)
 		if err != nil {
 			return nil, err
 		}

--- a/v2/cmd/voucher_client/config.go
+++ b/v2/cmd/voucher_client/config.go
@@ -36,6 +36,12 @@ func getVoucherClient() (voucher.Interface, error) {
 			newClient.SetBasicAuth(defaultConfig.Username, defaultConfig.Password)
 		}
 		return newClient, err
+	case "default-access-token":
+		newClient, err := NewAuthClientWithToken(defaultConfig.Server)
+		if err != nil {
+			return nil, err
+		}
+		return newClient, err
 	default:
 		return nil, fmt.Errorf("invalid auth value: %q", defaultConfig.Auth)
 	}

--- a/v2/cmd/voucher_client/defaultclient.go
+++ b/v2/cmd/voucher_client/defaultclient.go
@@ -41,19 +41,19 @@ func (s *idTokenSource) Token() (*oauth2.Token, error) {
 
 // NewAuthClientWithToken creates an auth client using the token created from ADC
 func NewAuthClientWithToken(ctx context.Context, voucherURL string) (*client.Client, error) {
-	ts, err := getDefaultTokenSource(ctx, voucherURL)
+	ts, err := getDefaultTokenSource(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := newHTTPClient(ctx, voucherURL, ts)
+	c, err := newHTTPClient(ctx, ts)
 	if err != nil {
 		return nil, err
 	}
 	return client.NewCustomClient(voucherURL, c)
 }
 
-func getDefaultTokenSource(ctx context.Context, audience string) (oauth2.TokenSource, error) {
+func getDefaultTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 	src, err := google.DefaultTokenSource(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error creating token source: %w", err)
@@ -62,7 +62,7 @@ func getDefaultTokenSource(ctx context.Context, audience string) (oauth2.TokenSo
 	return ts, nil
 }
 
-func newHTTPClient(ctx context.Context, audience string, ts oauth2.TokenSource) (*http.Client, error) {
+func newHTTPClient(ctx context.Context, ts oauth2.TokenSource) (*http.Client, error) {
 	t, err := htransport.NewTransport(ctx, http.DefaultTransport, option.WithTokenSource(ts))
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %w", err)

--- a/v2/cmd/voucher_client/defaultclient.go
+++ b/v2/cmd/voucher_client/defaultclient.go
@@ -54,7 +54,7 @@ func NewAuthClientWithToken(ctx context.Context, voucherURL string) (*client.Cli
 }
 
 func getDefaultTokenSource(ctx context.Context, audience string) (oauth2.TokenSource, error) {
-	src, err := google.DefaultTokenSource(context.Background())
+	src, err := google.DefaultTokenSource(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error creating token source: %w", err)
 	}
@@ -63,7 +63,7 @@ func getDefaultTokenSource(ctx context.Context, audience string) (oauth2.TokenSo
 }
 
 func newHTTPClient(ctx context.Context, audience string, ts oauth2.TokenSource) (*http.Client, error) {
-	t, err := htransport.NewTransport(context.Background(), http.DefaultTransport, option.WithTokenSource(ts))
+	t, err := htransport.NewTransport(ctx, http.DefaultTransport, option.WithTokenSource(ts))
 	if err != nil {
 		return nil, fmt.Errorf("error creating client: %w", err)
 	}

--- a/v2/cmd/voucher_client/defaultclient.go
+++ b/v2/cmd/voucher_client/defaultclient.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/grafeas/voucher/v2/client"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+	htransport "google.golang.org/api/transport/http"
+)
+
+// Implementation from: https://github.com/googleapis/google-api-go-client/issues/873
+// idTokenSource is an oauth2.TokenSource that wraps another
+// It takes the id_token from TokenSource and passes that on as a bearer token
+type idTokenSource struct {
+	TokenSource oauth2.TokenSource
+}
+
+func (s *idTokenSource) Token() (*oauth2.Token, error) {
+	token, err := s.TokenSource.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	idToken, ok := token.Extra("id_token").(string)
+	if !ok {
+		return nil, fmt.Errorf("token did not contain an id_token")
+	}
+
+	return &oauth2.Token{
+		AccessToken: idToken,
+		TokenType:   "Bearer",
+		Expiry:      token.Expiry,
+	}, nil
+}
+
+func NewAuthClientWithToken(voucherURL string) (*client.Client, error) {
+	c, err := newHttpClient()
+	if err != nil {
+		return nil, err
+	}
+	return client.NewCustomClient(voucherURL, c)
+}
+
+func getDefaultTokenSource() (oauth2.TokenSource, error) {
+	src, err := google.DefaultTokenSource(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	ts := oauth2.ReuseTokenSource(nil, &idTokenSource{TokenSource: src})
+	return ts, nil
+}
+
+func newHttpClient() (*http.Client, error) {
+	ts, err := getDefaultTokenSource()
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %w", err)
+	}
+
+	t, err := htransport.NewTransport(context.Background(), http.DefaultTransport, option.WithTokenSource(ts))
+	if err != nil {
+		return nil, fmt.Errorf("error creating client: %w", err)
+	}
+	return &http.Client{Transport: t}, nil
+}

--- a/v2/cmd/voucher_client/root.go
+++ b/v2/cmd/voucher_client/root.go
@@ -53,7 +53,7 @@ func init() {
 	viper.BindPFlag("timeout", rootCmd.Flags().Lookup("timeout"))
 	rootCmd.Flags().StringVarP(&defaultConfig.Check, "check", "c", "all", "the name of the checks to run against Voucher with")
 	viper.BindPFlag("check", rootCmd.Flags().Lookup("check"))
-	rootCmd.Flags().StringVarP(&defaultConfig.Auth, "auth", "a", "basic", "the method to authenticate against Voucher with. Supported types: basic, idtoken")
+	rootCmd.Flags().StringVarP(&defaultConfig.Auth, "auth", "a", "basic", "the method to authenticate against Voucher with. Supported types: basic, idtoken, default-access-token")
 	viper.BindPFlag("auth", rootCmd.Flags().Lookup("auth"))
 }
 


### PR DESCRIPTION
CloudBuild has some issues retrieving id_tokens from the metadata server resulting in the following error:

```
creating client failed: metadata: GCE metadata "instance/service-accounts/default/identity?audience=[someurl]" not defined
```

This pr aims to make auth using application-default-credentials possible, since it is exposed by GCB