### PR TITLE
logging: url as string

### DIFF
--- a/v2/server/log.go
+++ b/v2/server/log.go
@@ -21,7 +21,7 @@ func LogRequests(r *http.Request) {
 	}
 
 	log.WithFields(log.Fields{
-		"url":  r.URL,
+		"url":  r.URL.String(),
 		"path": r.URL.Path,
 		"form": r.Form,
 	}).Info("received request")


### PR DESCRIPTION
When logging requests, output the URL as a string instead of struct. This avoids outputting a bunch of uninteresting and empty fields.
The same information is logged, just more compact. This is very much a paper-cut.

Pre:
```json
{"form":{},"level":"info","msg":"received request","path":"/diy/verify","time":"2022-01-10T16:06:46Z","url":{"Scheme":"","Opaque":"","User":null,"Host":"","Path":"/diy/verify","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":"","RawFragment":""}}
```

Post:
```json
{"form":{},"level":"info","msg":"received request","path":"/diy/verify","time":"2022-01-10T16:06:46Z","url": "/diy/verify"}
```