### PR TITLE
voucher_client: maintain context

### DIFF
--- a/v2/cmd/voucher_client/config.go
+++ b/v2/cmd/voucher_client/config.go
@@ -25,7 +25,7 @@ func getCheck() string {
 	return defaultConfig.Check
 }
 
-func getVoucherClient() (voucher.Interface, error) {
+func getVoucherClient(ctx context.Context) (voucher.Interface, error) {
 	options := []client.Option{
 		client.WithUserAgent(fmt.Sprintf("voucher-client/%s", version)),
 	}
@@ -39,9 +39,6 @@ func getVoucherClient() (voucher.Interface, error) {
 	default:
 		return nil, fmt.Errorf("invalid auth value: %q", defaultConfig.Auth)
 	}
-
-	ctx, cancel := newContext()
-	defer cancel()
 	return client.NewClientContext(ctx, defaultConfig.Server, options...)
 }
 

--- a/v2/cmd/voucher_client/submit.go
+++ b/v2/cmd/voucher_client/submit.go
@@ -36,14 +36,14 @@ func check(ctx context.Context, client voucher.Interface, check string, canonica
 func LookupAndCheck(args []string) {
 	var err error
 
-	client, err := getVoucherClient()
+	ctx, cancel := newContext()
+	defer cancel()
+
+	client, err := getVoucherClient(ctx)
 	if nil != err {
 		errorf("creating client failed: %s", err)
 		os.Exit(1)
 	}
-
-	ctx, cancel := newContext()
-	defer cancel()
 
 	canonicalRef, err := lookupCanonical(ctx, args[0])
 	if nil != err {

--- a/v2/cmd/voucher_client/verify.go
+++ b/v2/cmd/voucher_client/verify.go
@@ -32,14 +32,14 @@ func verifyImage(ctx context.Context, client voucher.Interface, check string, ca
 func LookupAndVerify(args []string) {
 	var err error
 
-	client, err := getVoucherClient()
+	ctx, cancel := newContext()
+	defer cancel()
+
+	client, err := getVoucherClient(ctx)
 	if nil != err {
 		errorf("creating client failed: %s", err)
 		os.Exit(1)
 	}
-
-	ctx, cancel := newContext()
-	defer cancel()
 
 	canonicalRef, err := lookupCanonical(ctx, args[0])
 	if nil != err {


### PR DESCRIPTION
This fixes a bug where a client is instantiated with a context that is immediately cancelled, introduced by https://github.com/grafeas/voucher/pull/54. 