### PR TITLE
ReferenceToProject: support Artifact Registry

### DIFF
--- a/v2/auth/google/auth.go
+++ b/v2/auth/google/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/docker/distribution/reference"
 	"golang.org/x/oauth2"
@@ -51,7 +52,14 @@ func (a *gAuth) ToClient(ctx context.Context, image reference.Named) (*http.Clie
 
 // IsForDomain validates the domain part of the Named image reference
 func (a *gAuth) IsForDomain(image reference.Named) bool {
-	return "gcr.io" == reference.Domain(image)
+	domain := reference.Domain(image)
+	if domain == "gcr.io" {
+		// Google Container Registry
+		return true
+	}
+
+	// Google Artifact Registry
+	return strings.HasSuffix(domain, ".pkg.dev")
 }
 
 // NewAuth returns a new voucher.Auth to access Google specific resources.

--- a/v2/docker/uri/project.go
+++ b/v2/docker/uri/project.go
@@ -22,8 +22,11 @@ func (err *ErrNoProjectInReference) Error() string {
 // should start with `gcr.io/my-cool-project`.
 func ReferenceToProjectName(ref reference.Reference) (string, error) {
 	values := strings.Split(ref.String(), "/")
-	if 2 < len(values) {
+	if len(values) > 2 {
 		if values[0] == "gcr.io" {
+			return values[1], nil
+		}
+		if strings.HasSuffix(values[0], ".pkg.dev") {
 			return values[1], nil
 		}
 	}

--- a/v2/docker/uri/project_test.go
+++ b/v2/docker/uri/project_test.go
@@ -8,23 +8,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testImageReference = "gcr.io/alpine/alpine@sha256:297524b7375fbf09b3784f0bbd9cb2505700dd05e03ce5f5e6d262bf2f5ac51c"
-
 func TestReferenceToProjectName(t *testing.T) {
-	ref, err := reference.Parse(testImageReference)
-	require.NoError(t, err)
+	// map of reference to project
+	cases := map[string]string{
+		"gcr.io/alpine/alpine@sha256:297524b7375fbf09b3784f0bbd9cb2505700dd05e03ce5f5e6d262bf2f5ac51c": "alpine",
+		"alpine/alpine": "",
+		"southamerica-east1-docker.pkg.dev/my-project/team1/webapp":   "my-project",
+		"australia-southeast1-docker.pkg.dev/my-project/team2/webapp": "my-project",
+	}
+	for img, expectedProject := range cases {
+		t.Run(img, func(t *testing.T) {
+			ref, err := reference.Parse(img)
+			require.NoError(t, err)
 
-	project, err := ReferenceToProjectName(ref)
-	assert.NoError(t, err)
-	assert.Equal(t, "alpine", project)
-}
-
-func TestReferenceToProjectNameWithOtherReference(t *testing.T) {
-	ref, err := reference.Parse("alpine/alpine")
-
-	require.NoError(t, err)
-
-	project, err := ReferenceToProjectName(ref)
-	assert.Error(t, err)
-	assert.Equal(t, "", project)
+			project, err := ReferenceToProjectName(ref)
+			if expectedProject != "" {
+				assert.NoError(t, err)
+				assert.Equal(t, expectedProject, project)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Voucher parses registry URLs to map Google Container Registry URLs to the owning GCP project. This informs the project that is queried for build metadata about the image.
The Google Artifact Registry changes the URL syntax for images hosted in GCP projects.

This PR updates `ReferenceToProject` to detect projects from the Google Artifact Registry format URLs. Since the number of test cases grew to >= 3, I refactored to using a table-driven test.


# Related
- Reference https://cloud.google.com/artifact-registry/docs/docker/names
- General ref https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr
