### PR TITLE
go1.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.19
       - name: Extract release changelog
         run: |
           version=${GITHUB_REF#refs/tags/v*}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.19
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder
-FROM golang:1.16-alpine as builder
+FROM golang:1.19-alpine as builder
 
 LABEL maintainer "catherinejones"
 WORKDIR /go/src/github.com/grafeas/voucher
@@ -14,7 +14,7 @@ COPY . .
 RUN make voucher_server
 
 # Final build
-FROM alpine:3.12
+FROM alpine:3.16
 
 COPY --from=builder /go/src/github.com/grafeas/voucher/build/voucher_server /usr/local/bin/voucher_server
 COPY --from=builder /go/src/github.com/grafeas/voucher/entrypoint.sh /usr/local/entrypoint.sh

--- a/v2/client/client.go
+++ b/v2/client/client.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -180,7 +180,7 @@ func (c *Client) doVoucherRequest(ctx context.Context, url string, image referen
 	defer resp.Body.Close()
 
 	if !strings.Contains(resp.Header.Get("Content-Type"), "application/json") {
-		b, err := ioutil.ReadAll(resp.Body)
+		b, err := io.ReadAll(resp.Body)
 		if err == nil {
 			err = fmt.Errorf("failed to get response: %s", strings.TrimSpace(string(b)))
 		}

--- a/v2/cmd/config/metadataclient.go
+++ b/v2/cmd/config/metadataclient.go
@@ -46,7 +46,7 @@ func NewMetadataClient(ctx context.Context, secrets *Secrets) (voucher.MetadataC
 	}
 }
 
-//NewAttestationSigner creates a new attestation signer
+// NewAttestationSigner creates a new attestation signer
 func NewAttestationSigner(secrets *Secrets) signer.AttestationSigner {
 	signerName := viper.GetString("signer")
 	if signerName == "pgp" || signerName == "" {

--- a/v2/docker/call.go
+++ b/v2/docker/call.go
@@ -2,13 +2,13 @@ package docker
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
 // responseToError converts the body of a response to an error.
 func responseToError(resp *http.Response) error {
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if nil == err {
 		err = errors.New("failed to load resource with status \"" + resp.Status + "\": " + string(b))
 	}

--- a/v2/docker/manifest_request.go
+++ b/v2/docker/manifest_request.go
@@ -1,7 +1,7 @@
 package docker
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/docker/distribution"
@@ -17,7 +17,7 @@ func getDockerManifest(client *http.Client, request *http.Request) (distribution
 
 	defer resp.Body.Close()
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if nil != err {
 		return nil, NewManifestError(err)
 	}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafeas/voucher/v2
 
-go 1.16
+go 1.18
 
 require (
 	// if updating containeranalysis or grafeas, ensure the options in containeranalysis/client.go are still valid
@@ -17,20 +17,14 @@ require (
 	github.com/docker/distribution v2.6.0-rc.1.0.20180913220339-b089e9168825+incompatible
 	github.com/docker/docker v1.13.2-0.20170524085120-eef6495eddab
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
-	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
-	github.com/fernet/fernet-go v0.0.0-20180830025343-9eac43b88a5e // indirect
 	github.com/golang/mock v1.6.0
 	github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/gorilla/mux v1.6.2
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mennanov/fieldmask-utils v0.0.0-20190703161732-eca3212cf9f3
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/go-digest v1.0.0-rc1
-	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/shurcooL/githubv4 v0.0.0-20190718010115-4ba037080260
-	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	github.com/sirupsen/logrus v1.4.2
-	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.6.1
@@ -40,4 +34,102 @@ require (
 	google.golang.org/api v0.63.0
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa
 	google.golang.org/grpc v1.40.1
+)
+
+require (
+	cloud.google.com/go v0.99.0 // indirect
+	filippo.io/age v1.0.0-beta7 // indirect
+	github.com/Azure/azure-sdk-for-go v31.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.9.0 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.5.0 // indirect
+	github.com/Azure/go-autorest/autorest/azure/auth v0.1.0 // indirect
+	github.com/Azure/go-autorest/autorest/azure/cli v0.1.0 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.1.0 // indirect
+	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
+	github.com/Azure/go-autorest/logger v0.1.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.5.0 // indirect
+	github.com/aws/aws-sdk-go v1.37.18 // indirect
+	github.com/beorn7/perks v1.0.0 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/census-instrumentation/opencensus-proto v0.2.1 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403 // indirect
+	github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/dimchansky/utfbom v1.1.0 // indirect
+	github.com/docker/go-connections v0.4.0 // indirect
+	github.com/docker/go-units v0.4.0 // indirect
+	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
+	github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.1.0 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/fernet/fernet-go v0.0.0-20180830025343-9eac43b88a5e // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/google/go-github/v29 v29.0.2 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/goware/prefixer v0.0.0-20160118172347-395022866408 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-multierror v1.0.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.5.4 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.1 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/vault/api v1.0.4 // indirect
+	github.com/hashicorp/vault/sdk v0.1.13 // indirect
+	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/julienschmidt/httprouter v1.2.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/lib/pq v1.2.0 // indirect
+	github.com/magiconair/properties v1.8.0 // indirect
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.3 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v0.9.3 // indirect
+	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
+	github.com/prometheus/common v0.4.0 // indirect
+	github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
+	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
+	github.com/spf13/afero v1.1.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
+	go.mozilla.org/gopgagent v0.0.0-20170926210634-4d7ea76ff71a // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
+	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/ini.v1 v1.44.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.3.1 // indirect
+	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107172259-749611fa9fcc // indirect
 )

--- a/v2/grafeas/errors.go
+++ b/v2/grafeas/errors.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-//Grafeas client errors
+// Grafeas client errors
 var (
 	errNoOccurrences         = errors.New("no occurrences returned for image")
 	errDiscoveriesUnfinished = errors.New("discoveries have not finished processing")

--- a/v2/grafeas/grafeas_api_error.go
+++ b/v2/grafeas/grafeas_api_error.go
@@ -2,7 +2,7 @@ package grafeas
 
 import "fmt"
 
-//APIError to store grafeas API errors
+// APIError to store grafeas API errors
 type APIError struct {
 	statusCode  int
 	url         string

--- a/v2/grafeas/grafeas_service.go
+++ b/v2/grafeas/grafeas_service.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -131,7 +131,7 @@ func (g *apiServiceImpl) httpCall(urlAddr *url.URL, payload []byte, method strin
 		Method: method,
 		URL:    urlAddr,
 		Header: make(map[string][]string),
-		Body:   ioutil.NopCloser(bytes.NewReader(payload)),
+		Body:   io.NopCloser(bytes.NewReader(payload)),
 	}
 	req.Header.Add("Content-Type", "application/json")
 	resp, err := g.client.Do(&req)
@@ -145,7 +145,7 @@ func (g *apiServiceImpl) httpCall(urlAddr *url.URL, payload []byte, method strin
 	defer resp.Body.Close()
 
 	statusCode := resp.StatusCode
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if statusCode != http.StatusOK || err != nil {
 		return nil, NewAPIError(statusCode, urlAddr.Path, method, data)
 	}

--- a/v2/grafeas/grafeas_service.go
+++ b/v2/grafeas/grafeas_service.go
@@ -14,27 +14,27 @@ import (
 	"github.com/grafeas/voucher/v2/grafeas/objects"
 )
 
-//GrafeasAPIService vars
+// GrafeasAPIService vars
 var (
 	ErrTimeout = errors.New("timeout error when getting REST data")
 	timeout    = time.Minute
 )
 
-//APIService is the interface for communicating with Grafeas
+// APIService is the interface for communicating with Grafeas
 type APIService interface {
 	CreateOccurrence(context.Context, string, objects.Occurrence) (objects.Occurrence, error)
 	ListNotes(context.Context, string, *objects.ListOpts) (objects.ListNotesResponse, error)
 	ListOccurrences(context.Context, string, *objects.ListOpts) (objects.ListOccurrencesResponse, error)
 }
 
-//apiServiceImpl for REST calls
+// apiServiceImpl for REST calls
 type apiServiceImpl struct {
 	basePath    string
 	versionPath string
 	client      *http.Client
 }
 
-//NewAPIService creates new GrafeasAPIService
+// NewAPIService creates new GrafeasAPIService
 func NewAPIService(basePath, versionPath string) APIService {
 	return &apiServiceImpl{
 		basePath:    basePath,
@@ -45,8 +45,8 @@ func NewAPIService(basePath, versionPath string) APIService {
 	}
 }
 
-//CreateOccurrence based on
-//https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L310
+// CreateOccurrence based on
+// https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L310
 func (g *apiServiceImpl) CreateOccurrence(ctx context.Context, parent string, occurrence objects.Occurrence) (objects.Occurrence, error) {
 	urlPath, err := g.buildURL(parent, "/occurrences", nil)
 	if err != nil {
@@ -68,8 +68,8 @@ func (g *apiServiceImpl) CreateOccurrence(ctx context.Context, parent string, oc
 	return occ, nil
 }
 
-//ListNotes based on
-//https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L1057
+// ListNotes based on
+// https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L1057
 func (g *apiServiceImpl) ListNotes(ctx context.Context, parent string, optsNotes *objects.ListOpts) (objects.ListNotesResponse, error) {
 	urlPath, err := g.buildURL(parent, "/notes", optsNotes)
 	if err != nil {
@@ -87,8 +87,8 @@ func (g *apiServiceImpl) ListNotes(ctx context.Context, parent string, optsNotes
 	return notesResp, nil
 }
 
-//ListOccurrences based on
-//https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L1165
+// ListOccurrences based on
+// https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L1165
 func (g *apiServiceImpl) ListOccurrences(ctx context.Context, parent string, optsOccurrences *objects.ListOpts) (objects.ListOccurrencesResponse, error) {
 	urlPath, err := g.buildURL(parent, "/occurrences", optsOccurrences)
 	if err != nil {

--- a/v2/grafeas/objects/attestation.go
+++ b/v2/grafeas/objects/attestation.go
@@ -4,24 +4,24 @@ import (
 	voucher "github.com/grafeas/voucher/v2"
 )
 
-//AttestationSignedContentType based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_attestation_pgp_signed_attestation_content_type.go
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_attestation_generic_signed_attestation_content_type.go
+// AttestationSignedContentType based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_attestation_pgp_signed_attestation_content_type.go
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_attestation_generic_signed_attestation_content_type.go
 type AttestationSignedContentType string
 
-//consts
+// consts
 const (
 	AttestationUnspecified AttestationSignedContentType = "CONTENT_TYPE_UNSPECIFIED"
 	AttestationSigningJSON AttestationSignedContentType = "SIMPLE_SIGNING_JSON"
 )
 
-//AttestationDetails based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1attestation_details.go
+// AttestationDetails based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1attestation_details.go
 type AttestationDetails struct {
 	Attestation *Attestation `json:"attestation,omitempty"` //required
 }
 
-//AsVoucherAttestation converts objects.AttestationDetails to voucher.SignedAttestation
+// AsVoucherAttestation converts objects.AttestationDetails to voucher.SignedAttestation
 func (ad *AttestationDetails) AsVoucherAttestation(checkName string) voucher.SignedAttestation {
 	signedAttestation := voucher.SignedAttestation{
 		Attestation: voucher.Attestation{
@@ -34,7 +34,7 @@ func (ad *AttestationDetails) AsVoucherAttestation(checkName string) voucher.Sig
 	return signedAttestation
 }
 
-//NewAttestation creates a new attestation
+// NewAttestation creates a new attestation
 func NewAttestation(signedAttestation voucher.SignedAttestation) *AttestationDetails {
 	contentType := AttestationSigningJSON
 	return &AttestationDetails{Attestation: &Attestation{
@@ -43,22 +43,22 @@ func NewAttestation(signedAttestation voucher.SignedAttestation) *AttestationDet
 				PublicKeyID: signedAttestation.KeyID}}, ContentType: &contentType}}}
 }
 
-//Attestation based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_attestation_attestation.go
+// Attestation based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_attestation_attestation.go
 type Attestation struct {
 	GenericSignedAttestation *AttestationGenericSigned `json:"genericSignedAttestation,omitempty"`
 }
 
-//AttestationGenericSigned based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_attestation_generic_signed_attestation.go
+// AttestationGenericSigned based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_attestation_generic_signed_attestation.go
 type AttestationGenericSigned struct {
 	ContentType       *AttestationSignedContentType `json:"contentType,omitempty"`
 	Signatures        []Signature                   `json:"signatures,omitempty"`
 	SerializedPayload string                        `json:"serializedPayload,omitempty"`
 }
 
-//Signature based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_signature.go
+// Signature based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_signature.go
 type Signature struct {
 	Signature   []byte `json:"signature,omitempty"`
 	PublicKeyID string `json:"publicKeyId,omitempty"`

--- a/v2/grafeas/objects/build.go
+++ b/v2/grafeas/objects/build.go
@@ -8,15 +8,15 @@ import (
 
 //note objects
 
-//Build based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_build_build.go
+// Build based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_build_build.go
 type Build struct {
 	BuilderVersion string          `json:"builderVersion,omitempty"` //required
 	Signature      *BuildSignature `json:"signature,omitempty"`
 }
 
-//BuildSignature based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_build_build_signature.go
+// BuildSignature based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_build_build_signature.go
 type BuildSignature struct {
 	PublicKey string `json:"publicKey,omitempty"`
 	Signature string `json:"signature,omitempty"` //required
@@ -25,14 +25,14 @@ type BuildSignature struct {
 
 //occurrence objects
 
-//BuildDetails based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1build_details.go
+// BuildDetails based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1build_details.go
 type BuildDetails struct {
 	Provenance      *ProvenanceBuild `json:"provenance,omitempty"` //required
 	ProvenanceBytes string           `json:"provenanceBytes,omitempty"`
 }
 
-//AsVoucherBuildDetail converts an BuildDetails to a Build_Detail
+// AsVoucherBuildDetail converts an BuildDetails to a Build_Detail
 func (bd *BuildDetails) AsVoucherBuildDetail() (detail repository.BuildDetail) {
 	buildProvenance := bd.Provenance
 
@@ -55,8 +55,8 @@ func (bd *BuildDetails) AsVoucherBuildDetail() (detail repository.BuildDetail) {
 	return
 }
 
-//ProvenanceBuild based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_provenance_build_provenance.go
+// ProvenanceBuild based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_provenance_build_provenance.go
 type ProvenanceBuild struct {
 	ID               string               `json:"id,omitempty"` //required
 	ProjectID        string               `json:"projectId,omitempty"`
@@ -72,31 +72,31 @@ type ProvenanceBuild struct {
 	BuilderVersion   string               `json:"builderVersion,omitempty"`
 }
 
-//ProvenanceArtifact based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_provenance_artifact.go
+// ProvenanceArtifact based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_provenance_artifact.go
 type ProvenanceArtifact struct {
 	Checksum string   `json:"checksum,omitempty"`
 	ID       string   `json:"id,omitempty"`
 	Names    []string `json:"names,omitempty"`
 }
 
-//ProvenanceSource based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_provenance_source.go
+// ProvenanceSource based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_provenance_source.go
 type ProvenanceSource struct {
 	ArtifactStorageSourceURI string          `json:"artifactStorageSourceUri,omitempty"`
 	Context                  *SourceContext  `json:"context,omitempty"`
 	AdditionalContexts       []SourceContext `json:"additionalContexts,omitempty"`
 }
 
-//SourceContext based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_source_source_context.go
+// SourceContext based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_source_source_context.go
 type SourceContext struct {
 	Git    *GitSourceContext `json:"git,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
-//GitSourceContext based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_source_git_source_context.go
+// GitSourceContext based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_source_git_source_context.go
 type GitSourceContext struct { //SourceGitSourceContext
 	URL        string `json:"url,omitempty"`
 	RevisionID string `json:"revisionId,omitempty"`

--- a/v2/grafeas/objects/discovery.go
+++ b/v2/grafeas/objects/discovery.go
@@ -1,10 +1,10 @@
 package objects
 
-//DiscoveredAnalysisStatus based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_discovered_analysis_status.go
+// DiscoveredAnalysisStatus based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_discovered_analysis_status.go
 type DiscoveredAnalysisStatus string
 
-//consts
+// consts
 const (
 	DiscoveredAnalysisStatusUnspecified         DiscoveredAnalysisStatus = "ANALYSIS_STATUS_UNSPECIFIED"
 	DiscoveredAnalysisStatusPending             DiscoveredAnalysisStatus = "PENDING"
@@ -16,22 +16,22 @@ const (
 
 //discovery for occurrence
 
-//DiscoveryDetails based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1discovery_details.go
+// DiscoveryDetails based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1discovery_details.go
 type DiscoveryDetails struct {
 	Discovered *DiscoveryDiscovered `json:"discovered,omitempty"` //required
 }
 
-//DiscoveryDiscovered based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_discovery_discovered.go
+// DiscoveryDiscovered based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_discovery_discovered.go
 type DiscoveryDiscovered struct {
 	AnalysisStatus *DiscoveredAnalysisStatus `json:"analysisStatus,omitempty"`
 }
 
 //discovery for note
 
-//Discovery based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_discovery_discovery.go
+// Discovery based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_discovery_discovery.go
 type Discovery struct {
 	AnalysisKind *NoteKind `json:"analysisKind,omitempty"` //required
 }

--- a/v2/grafeas/objects/exchange.go
+++ b/v2/grafeas/objects/exchange.go
@@ -4,24 +4,24 @@ import (
 	"github.com/antihax/optional"
 )
 
-//ListOpts based on
-//ListNotesOpts https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L1051
-//ListNoteOccurrencesOpts https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L943
+// ListOpts based on
+// ListNotesOpts https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L1051
+// ListNoteOccurrencesOpts https://github.com/grafeas/client-go/blob/39fa98b49d38de3942716c0f58f3505012415470/0.1.0/api_grafeas_v1_beta1.go#L943
 type ListOpts struct {
 	Filter    optional.String //not implemented for grafeas os
 	PageSize  optional.Int32
 	PageToken optional.String
 }
 
-//ListNotesResponse based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_list_notes_response.go
+// ListNotesResponse based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_list_notes_response.go
 type ListNotesResponse struct {
 	Notes         []Note `json:"notes,omitempty"`
 	NextPageToken string `json:"nextPageToken,omitempty"`
 }
 
-//ListOccurrencesResponse based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_list_note_occurrences_response.go
+// ListOccurrencesResponse based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_list_note_occurrences_response.go
 type ListOccurrencesResponse struct {
 	Occurrences   []Occurrence `json:"occurrences,omitempty"`
 	NextPageToken string       `json:"nextPageToken,omitempty"`

--- a/v2/grafeas/objects/note.go
+++ b/v2/grafeas/objects/note.go
@@ -2,11 +2,11 @@ package objects
 
 import "time"
 
-//NoteKind based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_note_kind.go
+// NoteKind based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_note_kind.go
 type NoteKind string
 
-//consts
+// consts
 const (
 	NoteKindUspecified    NoteKind = "NOTE_KIND_UNSPECIFIED"
 	NoteKindVulnerability NoteKind = "VULNERABILITY"
@@ -18,8 +18,8 @@ const (
 	NoteKindAttestation   NoteKind = "ATTESTATION"
 )
 
-//Note based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_note.go
+// Note based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_note.go
 type Note struct {
 	Name             string         `json:"name,omitempty"` //output only
 	ShortDescription string         `json:"shortDescription,omitempty"`

--- a/v2/grafeas/objects/occurrence.go
+++ b/v2/grafeas/objects/occurrence.go
@@ -6,8 +6,8 @@ import (
 	"github.com/docker/distribution/reference"
 )
 
-//Occurrence based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_occurrence.go
+// Occurrence based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_occurrence.go
 type Occurrence struct {
 	//output only, form: `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]
 	Name          string                `json:"name,omitempty"`
@@ -23,13 +23,13 @@ type Occurrence struct {
 	Attestation   *AttestationDetails   `json:"attestation,omitempty"`
 }
 
-//Resource based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_resource.go
+// Resource based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1_resource.go
 type Resource struct {
 	URI string `json:"uri,omitempty"` //required
 }
 
-//NewOccurrence creates new occurrence
+// NewOccurrence creates new occurrence
 func NewOccurrence(reference reference.Canonical, parentNoteID string, attestation *AttestationDetails, binauthProjectPath string) Occurrence {
 	noteName := binauthProjectPath + "/notes/" + parentNoteID
 

--- a/v2/grafeas/objects/package.go
+++ b/v2/grafeas/objects/package.go
@@ -1,10 +1,10 @@
 package objects
 
-//VersionKind based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_version_version_kind.go
+// VersionKind based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_version_version_kind.go
 type VersionKind string
 
-//consts
+// consts
 const (
 	VersionKindUnspecified VersionKind = "VERSION_KIND_UNSPECIFIED"
 	VersionKindNormal      VersionKind = "NORMAL"
@@ -12,14 +12,14 @@ const (
 	VVersionKindMaximum    VersionKind = "MAXIMUM"
 )
 
-//Package based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_package_package.go
+// Package based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_package_package.go
 type Package struct {
 	Name string `json:"name,omitempty"` //required
 }
 
-//PackageVersion based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_package_version.go
+// PackageVersion based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_package_version.go
 type PackageVersion struct {
 	Epoch    int32        `json:"epoch,omitempty"`
 	Name     string       `json:"name,omitempty"` //required only when version kind is NORMAL

--- a/v2/grafeas/objects/vulnerability.go
+++ b/v2/grafeas/objects/vulnerability.go
@@ -6,11 +6,11 @@ import (
 	voucher "github.com/grafeas/voucher/v2"
 )
 
-//VulnerabilitySeverity based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_vulnerability_severity.go
+// VulnerabilitySeverity based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_vulnerability_severity.go
 type VulnerabilitySeverity string
 
-//consts
+// consts
 const (
 	SeverityUnspecified VulnerabilitySeverity = "SEVERITY_UNSPECIFIED"
 	SeverityMinimal     VulnerabilitySeverity = "MINIMAL"
@@ -20,8 +20,8 @@ const (
 	SeverityCritical    VulnerabilitySeverity = "CRITICAL"
 )
 
-//Vulnerability based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_vulnerability_vulnerability.go
+// Vulnerability based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_vulnerability_vulnerability.go
 type Vulnerability struct {
 	CvssScore float32                `json:"cvssScore,omitempty"`
 	Severity  *VulnerabilitySeverity `json:"severity,omitempty"`
@@ -29,8 +29,8 @@ type Vulnerability struct {
 
 //vulnerability for occurrence
 
-//VulnerabilityDetails based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1vulnerability_details.go
+// VulnerabilityDetails based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_v1beta1vulnerability_details.go
 type VulnerabilityDetails struct {
 	Type              string                      `json:"type,omitempty"`
 	Severity          *VulnerabilitySeverity      `json:"severity,omitempty"`         //output only
@@ -71,15 +71,15 @@ func getSeverity(severity *VulnerabilitySeverity) voucher.Severity {
 	return voucher.UnknownSeverity
 }
 
-//VulnerabilityPackageIssue based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_vulnerability_package_issue.go
+// VulnerabilityPackageIssue based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_vulnerability_package_issue.go
 type VulnerabilityPackageIssue struct {
 	AffectedLocation *VulnerabilityLocation `json:"affectedLocation,omitempty"` //required
 	FixedLocation    *VulnerabilityLocation `json:"fixedLocation,omitempty"`
 }
 
-//VulnerabilityLocation based on
-//https://github.com/grafeas/client-go/blob/master/0.1.0/model_vulnerability_vulnerability_location.go
+// VulnerabilityLocation based on
+// https://github.com/grafeas/client-go/blob/master/0.1.0/model_vulnerability_vulnerability_location.go
 type VulnerabilityLocation struct {
 	CpeURI  string          `json:"cpeUri,omitempty"`  //required
 	Package string          `json:"package,omitempty"` //required

--- a/v2/signer/pgp/sign.go
+++ b/v2/signer/pgp/sign.go
@@ -5,7 +5,7 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"golang.org/x/crypto/openpgp"
 	"golang.org/x/crypto/openpgp/armor"
@@ -87,7 +87,7 @@ func Verify(keyring openpgp.KeyRing, signed string) (string, error) {
 		return "", errNoSigner
 	}
 
-	body, err := ioutil.ReadAll(messageDetails.UnverifiedBody)
+	body, err := io.ReadAll(messageDetails.UnverifiedBody)
 	if nil != err {
 		if nil != messageDetails.SignatureError {
 			err = messageDetails.SignatureError

--- a/v2/suite.go
+++ b/v2/suite.go
@@ -58,7 +58,7 @@ func runner(ctx context.Context, name string, check Check, imageData ImageData, 
 //
 // For example, if a Suite has the "diy" and "nobody" tests, calling
 //
-//    Run(imageData)
+//	Run(imageData)
 //
 // will run the "diy" and "nobody" tests.
 //


### PR DESCRIPTION
* Update `go.mod` so that `>= go1.18` is required. This is for generics.
* Update the version of go used to test+compile to `go1.19`.
* Update the `Dockerfile` alpine base to the latest release
* Run `gofmt` to fix the linter issues
* Replace `io/ioutil` with `io` where applicable, to fix the linter issues