### PR TITLE
Fallback build details project

### DIFF
--- a/v2/cmd/config/metadataclient.go
+++ b/v2/cmd/config/metadataclient.go
@@ -26,6 +26,7 @@ func NewMetadataClient(ctx context.Context, secrets *Secrets) (voucher.MetadataC
 		return containeranalysis.NewClient(
 			ctx,
 			viper.GetString("binauth_project"),
+			viper.GetString("containeranalysis.build_detail_fallback_project"),
 			keyring,
 		)
 	case "grafeasos":
@@ -41,6 +42,7 @@ func NewMetadataClient(ctx context.Context, secrets *Secrets) (voucher.MetadataC
 		return containeranalysis.NewClient(
 			ctx,
 			viper.GetString("binauth_project"),
+			viper.GetString("containeranalysis.build_detail_fallback_project"),
 			keyring,
 		)
 	}

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -23,9 +23,10 @@ var errCannotAttest = errors.New("cannot create attestations, keyring is empty")
 
 // Client implements voucher.MetadataClient, connecting to containeranalysis Grafeas.
 type Client struct {
-	containeranalysis *grafeasv1.Client        // The client reference.
-	keyring           signer.AttestationSigner // The keyring used for signing metadata.
-	binauthProject    string                   // The project that Binauth Notes and Occurrences are written to.
+	containeranalysis  *grafeasv1.Client        // The client reference.
+	keyring            signer.AttestationSigner // The keyring used for signing metadata.
+	binauthProject     string                   // The project that Binauth Notes and Occurrences are written to.
+	buildDetailProject string                   // [optional] the fallback project where Build Notes are written to.
 }
 
 // CanAttest returns true if the client can create and sign attestations.
@@ -166,47 +167,69 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 		return repository.BuildDetail{}, err
 	}
 
-	// appEnv := os.Getenv("APP_ENV")
-
-	// if appEnv == "production" {
 	parent := projectPath(project)
-	// } else {
-	// 	parent = "projects/shopify-docker-images"
-	// }
 
-	req := &grafeas.ListOccurrencesRequest{Parent: parent, Filter: filterStr}
-	occIterator := g.containeranalysis.ListOccurrences(ctx, req)
+	// Scan thru image project for build details and fallback to buildDetailProject if buildDetailProject is set.
+	// and the build details are not found in the image project.
+	// Cases:
+	// 1. No build notes found for image + fallback (image does not have build metadata)
+	// 2. No build notes found for image project, but build notes found for fallback project (image has a central local for storing build metadata)
+	// 3. Build notes found for image project (image has build metadata)
+	// 4. Image has multiple build notes (image has build metadata)
+	projectToScan := []string{parent}
+	if g.buildDetailProject != "" {
+		projectToScan = append(projectToScan, g.buildDetailProject)
+	}
 
-	occ, err := occIterator.Next()
-	if err != nil {
-		if err == iterator.Done {
-			err = &voucher.NoMetadataError{
-				Type: voucher.VulnerabilityType,
-				Err:  errNoOccurrences,
-			}
+	buildDetail := repository.BuildDetail{}
+	for _, project := range projectToScan {
+		req := &grafeas.ListOccurrencesRequest{Parent: parent, Filter: filterStr}
+		occIterator := g.containeranalysis.ListOccurrences(ctx, req)
+
+		occ, err := occIterator.Next()
+
+		// If this is the first project and it errors, we can continue to the fallback
+		if project != g.buildDetailProject && err != nil {
+			continue
 		}
-		return repository.BuildDetail{}, err
-	}
 
-	if _, err := occIterator.Next(); err != iterator.Done {
-		return repository.BuildDetail{}, errors.New("Found multiple Grafeas occurrences for " + ref.String())
-	}
+		if err != nil {
+			return repository.BuildDetail{}, toIterError(err)
+		}
 
-	return OccurrenceToBuildDetail(occ), nil
+		// Muliple build notes found - invalid
+		if _, err := occIterator.Next(); err != iterator.Done {
+			return repository.BuildDetail{}, errors.New("Found multiple Grafeas occurrences for " + ref.String())
+		}
+
+		buildDetail = OccurrenceToBuildDetail(occ)
+	}
+	return buildDetail, nil
 }
 
 // NewClient creates a new containeranalysis Grafeas Client.
-func NewClient(ctx context.Context, binauthProject string, keyring signer.AttestationSigner) (*Client, error) {
+func NewClient(ctx context.Context, binauthProject string, buildDetailproject string, keyring signer.AttestationSigner) (*Client, error) {
 	// These options emulate cloud.google.com/go/containeranalysis/apiv1.NewClient
 	grafeasClient, err := grafeasv1.NewClient(ctx, option.WithEndpoint("containeranalysis.googleapis.com:443"), option.WithScopes(containeranalysisapi.DefaultAuthScopes()...))
 	if err != nil {
 		return nil, err
 	}
 	client := &Client{
-		containeranalysis: grafeasClient,
-		keyring:           keyring,
-		binauthProject:    binauthProject,
+		containeranalysis:  grafeasClient,
+		keyring:            keyring,
+		binauthProject:     binauthProject,
+		buildDetailProject: buildDetailproject,
 	}
 
 	return client, nil
+}
+
+func toIterError(err error) error {
+	if err == iterator.Done {
+		return &voucher.NoMetadataError{
+			Type: voucher.VulnerabilityType,
+			Err:  errNoOccurrences,
+		}
+	}
+	return err
 }

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -166,7 +166,7 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 	}
 
 	buildDetail, err := g.getBuildDetailFromProject(ctx, project, ref)
-	if err != nil && g.buildDetailProject != "" {
+	if err != nil && g.buildDetailProject != "" && g.buildDetailProject != project {
 		return g.getBuildDetailFromProject(ctx, g.buildDetailProject, ref)
 	}
 

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -166,7 +166,15 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 		return repository.BuildDetail{}, err
 	}
 
-	req := &grafeas.ListOccurrencesRequest{Parent: projectPath(project), Filter: filterStr}
+	// appEnv := os.Getenv("APP_ENV")
+
+	// if appEnv == "production" {
+	parent := projectPath(project)
+	// } else {
+	// 	parent = "projects/shopify-docker-images"
+	// }
+
+	req := &grafeas.ListOccurrencesRequest{Parent: parent, Filter: filterStr}
 	occIterator := g.containeranalysis.ListOccurrences(ctx, req)
 
 	occ, err := occIterator.Next()

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -3,6 +3,7 @@ package containeranalysis
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	containeranalysisapi "cloud.google.com/go/containeranalysis/apiv1"
 	grafeasv1 "cloud.google.com/go/grafeas/apiv1"
@@ -180,6 +181,7 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 	if g.buildDetailProject != "" {
 		projectToScan = append(projectToScan, projectPath(g.buildDetailProject))
 	}
+	fmt.Println("projectToScan:", projectToScan)
 
 	buildDetail := repository.BuildDetail{}
 	for _, project := range projectToScan {
@@ -189,7 +191,7 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 		occ, err := occIterator.Next()
 
 		// If this is the first project and it errors, we can continue to the fallback
-		if project != g.buildDetailProject && err != nil {
+		if project != g.buildDetailProject && g.buildDetailProject != "" && err != nil {
 			continue
 		}
 

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -204,7 +204,7 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 			return repository.BuildDetail{}, err
 		}
 
-		// Muliple build notes found - invalid
+		// Multiple build notes found - invalid
 		if _, err := occIterator.Next(); err != iterator.Done {
 			return repository.BuildDetail{}, errors.New("Found multiple Grafeas occurrences for " + ref.String())
 		}

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -184,12 +184,11 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 
 	buildDetail := repository.BuildDetail{}
 	for _, project := range projectToScan {
-		req := &grafeas.ListOccurrencesRequest{Parent: parent, Filter: filterStr}
+		req := &grafeas.ListOccurrencesRequest{Parent: project, Filter: filterStr}
 		occIterator := g.containeranalysis.ListOccurrences(ctx, req)
 
 		occ, err := occIterator.Next()
 
-		// If this is the first project and it errors, we can continue to the fallback
 		if !strings.HasSuffix(project, g.buildDetailProject) && err != nil {
 			continue
 		}

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -3,7 +3,7 @@ package containeranalysis
 import (
 	"context"
 	"errors"
-	"fmt"
+	"strings"
 
 	containeranalysisapi "cloud.google.com/go/containeranalysis/apiv1"
 	grafeasv1 "cloud.google.com/go/grafeas/apiv1"
@@ -181,7 +181,6 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 	if g.buildDetailProject != "" {
 		projectToScan = append(projectToScan, projectPath(g.buildDetailProject))
 	}
-	fmt.Println("projectToScan:", projectToScan)
 
 	buildDetail := repository.BuildDetail{}
 	for _, project := range projectToScan {
@@ -191,7 +190,7 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 		occ, err := occIterator.Next()
 
 		// If this is the first project and it errors, we can continue to the fallback
-		if project != g.buildDetailProject && g.buildDetailProject != "" && err != nil {
+		if !strings.HasSuffix(project, g.buildDetailProject) && err != nil {
 			continue
 		}
 

--- a/v2/containeranalysis/client.go
+++ b/v2/containeranalysis/client.go
@@ -178,7 +178,7 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 	// 4. Image has multiple build notes (image has build metadata)
 	projectToScan := []string{parent}
 	if g.buildDetailProject != "" {
-		projectToScan = append(projectToScan, g.buildDetailProject)
+		projectToScan = append(projectToScan, projectPath(g.buildDetailProject))
 	}
 
 	buildDetail := repository.BuildDetail{}

--- a/v2/grafeas/client.go
+++ b/v2/grafeas/client.go
@@ -137,7 +137,6 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 		return repository.BuildDetail{}, err
 	}
 
-	// TODO: Figure out if we need to add a fallback project for build details.
 	items, err := g.getAllOccurrences(ctx, project)
 	if nil != err {
 		return repository.BuildDetail{}, err

--- a/v2/grafeas/client.go
+++ b/v2/grafeas/client.go
@@ -137,6 +137,7 @@ func (g *Client) GetBuildDetail(ctx context.Context, ref reference.Canonical) (r
 		return repository.BuildDetail{}, err
 	}
 
+	// TODO: Figure out if we need to add a fallback project for build details.
 	items, err := g.getAllOccurrences(ctx, project)
 	if nil != err {
 		return repository.BuildDetail{}, err

--- a/v2/server/check.go
+++ b/v2/server/check.go
@@ -49,7 +49,7 @@ func (s *Server) handleChecks(w http.ResponseWriter, r *http.Request, name ...st
 		// If no buildDetail is found, we will skip initializing the repository client.
 		buildDetail, buildErr := metadataClient.GetBuildDetail(ctx, imageData)
 		if buildErr != nil {
-			LogWarning(fmt.Sprintf("could not get image metadata for %s. Skipping repository client initialization", imageData), err)
+			LogWarning(fmt.Sprintf("could not get image metadata for %s. Skipping repository client initialization", imageData), buildErr)
 		} else {
 			repositoryClient, err = config.NewRepositoryClient(ctx, s.secrets.RepositoryAuthentication, buildDetail.RepositoryURL)
 			if err != nil {

--- a/v2/server/check.go
+++ b/v2/server/check.go
@@ -62,7 +62,6 @@ func (s *Server) handleChecks(w http.ResponseWriter, r *http.Request, name ...st
 		// Get the buildDetail from the metadataClient.
 		// If no buildDetail is found, we will skip initializing the repository client.
 		buildDetail, err := metadataClient.GetBuildDetail(ctx, imageData)
-		LogInfo(fmt.Sprintf("buildDetail: %+v", buildDetail))
 		if err != nil {
 			LogWarning(fmt.Sprintf("could not get image metadata for %s. Skipping repository client initalization", imageData), err)
 		} else {

--- a/v2/server/check.go
+++ b/v2/server/check.go
@@ -43,16 +43,16 @@ func (s *Server) handleChecks(w http.ResponseWriter, r *http.Request, name ...st
 	}
 	defer metadataClient.Close()
 
-	// Initalize repository client if and only if we have a secrets that represents the org repo
+	// Initialize repository client if and only if we have a secrets that represents the org repo
 	if s.secrets != nil {
 		// Get the buildDetail from the metadataClient.
 		// If no buildDetail is found, we will skip initializing the repository client.
 		buildDetail, err := metadataClient.GetBuildDetail(ctx, imageData)
 		if err != nil {
-			LogWarning(fmt.Sprintf("could not get image metadata for %s. Skipping repository client initalization", imageData), err)
+			LogWarning(fmt.Sprintf("could not get image metadata for %s. Skipping repository client initialization", imageData), err)
 		} else {
 			repositoryClient, err = config.NewRepositoryClient(ctx, s.secrets.RepositoryAuthentication, buildDetail.RepositoryURL)
-			if nil != err {
+			if err != nil {
 				LogWarning("failed to create repository client, continuing without git repo support:", err)
 			}
 		}

--- a/v2/server/check.go
+++ b/v2/server/check.go
@@ -62,6 +62,7 @@ func (s *Server) handleChecks(w http.ResponseWriter, r *http.Request, name ...st
 		// Get the buildDetail from the metadataClient.
 		// If no buildDetail is found, we will skip initializing the repository client.
 		buildDetail, err := metadataClient.GetBuildDetail(ctx, imageData)
+		LogInfo(fmt.Sprintf("buildDetail: %+v", buildDetail))
 		if err != nil {
 			LogWarning(fmt.Sprintf("could not get image metadata for %s. Skipping repository client initalization", imageData), err)
 		} else {

--- a/v2/server/check.go
+++ b/v2/server/check.go
@@ -47,8 +47,8 @@ func (s *Server) handleChecks(w http.ResponseWriter, r *http.Request, name ...st
 	if s.secrets != nil {
 		// Get the buildDetail from the metadataClient.
 		// If no buildDetail is found, we will skip initializing the repository client.
-		buildDetail, err := metadataClient.GetBuildDetail(ctx, imageData)
-		if err != nil {
+		buildDetail, buildErr := metadataClient.GetBuildDetail(ctx, imageData)
+		if buildErr != nil {
 			LogWarning(fmt.Sprintf("could not get image metadata for %s. Skipping repository client initialization", imageData), err)
 		} else {
 			repositoryClient, err = config.NewRepositoryClient(ctx, s.secrets.RepositoryAuthentication, buildDetail.RepositoryURL)

--- a/v2/server/check.go
+++ b/v2/server/check.go
@@ -43,20 +43,6 @@ func (s *Server) handleChecks(w http.ResponseWriter, r *http.Request, name ...st
 	}
 	defer metadataClient.Close()
 
-	// buildDetail, err := metadataClient.GetBuildDetail(ctx, imageData)
-	// if nil != err {
-	// 	LogWarning(fmt.Sprintf("could not get image metadata for %s", imageData), err)
-	// } else {
-	// 	if s.secrets != nil {
-	// 		repositoryClient, err = config.NewRepositoryClient(ctx, s.secrets.RepositoryAuthentication, buildDetail.RepositoryURL)
-	// 		if nil != err {
-	// 			LogWarning("failed to create repository client, continuing without git repo support:", err)
-	// 		}
-	// 	} else {
-	// 		log.Warning("failed to create repository client, no secrets configured")
-	// 	}
-	// }
-
 	// Initalize repository client if and only if we have a secrets that represents the org repo
 	if s.secrets != nil {
 		// Get the buildDetail from the metadataClient.


### PR DESCRIPTION
This is cherry-picking @rxbchen and @chrisshino 's work in https://github.com/Shopify/voucher/pull/16 onto the current `grafeas/voucher`: I ran `git cherry-pick dab0b6902f2542ada0f6cede2c962866c5d7b1ef^..0935f52c7f2c0f735d9c102b136ff9b1c476a4cc`, then biased towards "incoming changes" to resolve conflicts.

In https://github.com/grafeas/voucher/issues/47#issuecomment-982019107 , Shopify made a nasty hack and forked Voucher to avoid polluting upstream. We'd like to finish that work correctly, so this is part of the housekeeping to bring the branches closer.

---

### What?

Added a new configuration that allows user to configure a fallback project for when build metadata is not found in the same project as the image.

### Why?

This addresses the issue where an image and it's corresponding build metadata lives in different GCP projects causing excessive warning logs to be emitted 

### How?

This is done by adding a configuration:

```toml
[containeranalysis]
build_detail_fallback_project = "project_name"
```

If this field is not empty, we will attempt to get image build metadata from there when any error occurs

### Checklist

#### Before Merging

- [ ] I have 🎩'd this locally
  - [ ] If this is complex to 🎩, I have provided instructions for others
- [ ] I have requested reviews or pinged the relevant persons/teams
