### PR TITLE
Silence golangci openpgp

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,6 @@ run:
 
   modules-download-mode: readonly
 
-
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
@@ -84,7 +83,7 @@ linters-settings:
     # with golangci-lint call it on a directory with the changed file.
     check-exported: false
   whitespace:
-    multi-if: false   # Enforces newlines (or comments) after every multi-line if statement
+    multi-if: false # Enforces newlines (or comments) after every multi-line if statement
     multi-func: false # Enforces newlines (or comments) after every multi-line function signature
   wsl:
     # If true append is only allowed to be cuddled if appending value is
@@ -116,7 +115,6 @@ linters:
     - bodyclose
   fast: false
 
-
 issues:
   exclude-rules:
     # Exclude some linters from running on tests files.
@@ -138,11 +136,12 @@ issues:
     - linters:
         - staticcheck
       text: "SA9003:"
-
-    # Exclude some staticcheck messages
     - linters:
         - staticcheck
       text: "SA5001:"
+    - linters:
+        - staticcheck
+      text: "SA1019:"
 
     # Exclude some staticcheck messages
     - linters:
@@ -169,7 +168,6 @@ issues:
         - varcheck
         - deadcode
       text: "`commit` is unused"
-
 
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,9 +42,6 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/grafeas/voucher
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
   govet:
     # report about shadowed variables
     check-shadowing: true
@@ -109,7 +106,6 @@ linters:
   enable:
     - megacheck
     - govet
-    - golint
     - ineffassign
     - misspell
     - gocyclo
@@ -150,7 +146,7 @@ issues:
 
     # Exclude some staticcheck messages
     - linters:
-        - errcheck 
+        - errcheck
       text: "Error return value of `viper.BindPFlag`"
 
     # Exclude lll issues for long lines with go:generate
@@ -161,14 +157,6 @@ issues:
     - linters:
         - errcheck
       text: "^Error return value of `.*\\.Close` is not checked"
-
-    - linters:
-        - golint 
-      text: "^exported .* should have comment.*or be unexported"
-
-    - linters:
-        - golint 
-      text: "KeysById"
 
     - linters:
         - unused


### PR DESCRIPTION
In https://github.com/grafeas/voucher/actions/runs/3440583419/jobs/5739216775 , we can observe that CI is failing because of an unmaintained dependency.

>  Error: SA1019: "golang.org/x/crypto/openpgp/packet" is deprecated: this package is unmaintained except for security fixes. New applications should consider a more focused, modern alternative to OpenPGP for their specific task. If you are required to interoperate with OpenPGP systems and need a maintained package, consider a community fork. See https://golang.org/issue/44226.  (staticcheck)

We should either fix that, or remove the PGP code (because it's secondary to the KMS+containeranalysis path).

This PR takes a minimal approach by silencing the warning, so other changes aren't blocked on this.

It also removes `golint` and rules, because it has been deprecated since `golangci-lint-1.41`.