### PR TITLE
Support OCI Image Index ManifestType

### DIFF
--- a/v2/cmd/voucher_client/digest.go
+++ b/v2/cmd/voucher_client/digest.go
@@ -31,6 +31,7 @@ func getCanonicalReference(client *http.Client, ref reference.Reference) (refere
 		if nil != err {
 			return nil, fmt.Errorf("making canonical reference failed: %s", err)
 		}
+
 		return canonicalRef, nil
 	}
 	return nil, fmt.Errorf("reference cannot be converted to a canonical reference")

--- a/v2/docker/digest.go
+++ b/v2/docker/digest.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/manifest/ocischema"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/docker/distribution/manifest/schema2"
@@ -24,6 +25,8 @@ func GetDigestFromTagged(client *http.Client, image reference.NamedTagged) (dige
 	}
 
 	request.Header.Add("Accept", ocischema.SchemaVersion.MediaType)
+	request.Header.Add("Accept", manifestlist.OCISchemaVersion.MediaType)
+	request.Header.Add("Accept", manifestlist.MediaTypeManifestList)
 	request.Header.Add("Accept", schema2.MediaTypeManifest)
 	request.Header.Add("Accept", schema1.MediaTypeManifest)
 	request.Header.Add("Accept", schema1.MediaTypeSignedManifest)
@@ -39,7 +42,7 @@ func GetDigestFromTagged(client *http.Client, image reference.NamedTagged) (dige
 	}
 
 	imageDigest := digest.Digest(resp.Header.Get("Docker-Content-Digest"))
-	if "" == string(imageDigest) {
+	if string(imageDigest) == "" {
 		return blank, errors.New("empty digest returned for image")
 	}
 

--- a/v2/docker/ocischema/manifest.go
+++ b/v2/docker/ocischema/manifest.go
@@ -16,8 +16,14 @@ import (
 // IsManifest returns true if the passed manifest is a schema2 manifest.
 func IsManifest(m distribution.Manifest) bool {
 	switch m.(type) {
-	case *ocischema.DeserializedManifest, manifestlist.DeserializedManifestList:
+	case *ocischema.DeserializedManifest:
 		return true
+	case *manifestlist.DeserializedManifestList:
+		mType, _, _ := m.Payload()
+		if mType == manifestlist.OCISchemaVersion.MediaType {
+			return true
+		}
+		return false
 	default:
 		return false
 	}
@@ -61,7 +67,7 @@ func resolveManifestFromList(client *http.Client, ref reference.Named, mfs *mani
 		if err != nil {
 			return ocischema.Manifest{}, fmt.Errorf("preparing request to fetch manifest from list: %w", err)
 		}
-		req.Header.Add("Accept", manifestlist.OCISchemaVersion.MediaType)
+		req.Header.Add("Accept", ocischema.SchemaVersion.MediaType)
 
 		resp, err := client.Do(req)
 		if err != nil {

--- a/v2/docker/schema2/manifest.go
+++ b/v2/docker/schema2/manifest.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/docker/distribution"
 	"github.com/docker/distribution/manifest/manifestlist"
-	"github.com/docker/distribution/manifest/schema2"
 	v2 "github.com/docker/distribution/manifest/schema2"
 	"github.com/docker/distribution/reference"
 	"github.com/grafeas/voucher/v2/docker/uri"
@@ -17,8 +16,14 @@ import (
 // IsManifest returns true if the passed manifest is a schema2 manifest.
 func IsManifest(m distribution.Manifest) bool {
 	switch m.(type) {
-	case *v2.DeserializedManifest, *manifestlist.DeserializedManifestList:
+	case *v2.DeserializedManifest:
 		return true
+	case *manifestlist.DeserializedManifestList:
+		mType, _, _ := m.Payload()
+		if mType == manifestlist.MediaTypeManifestList {
+			return true
+		}
+		return false
 	default:
 		return false
 	}
@@ -62,7 +67,7 @@ func resolveManifestFromList(client *http.Client, ref reference.Named, mfs *mani
 		if err != nil {
 			return v2.Manifest{}, fmt.Errorf("preparing request to fetch manifest from list: %w", err)
 		}
-		req.Header.Add("Accept", schema2.MediaTypeManifest)
+		req.Header.Add("Accept", v2.MediaTypeManifest)
 
 		resp, err := client.Do(req)
 		if err != nil {


### PR DESCRIPTION
Follow up to: https://github.com/grafeas/voucher/pull/81. 

We recently added support for oci image specs, however, this introduced a bug when trying to pull the manifest for an image of type: `application/vnd.oci.image.index.v1+json`. When attempting to pull the oci manifest, it instead of the schema2 manifest. Resulting in the following error:

```bash
$ go run ./cmd/voucher_client -v <voucher-server> -c diy <insert-oci-image-here>

Using config file: /Users/bchen/.voucher.yaml
Submitting image to Voucher: <insert-oci-image-here>
image was rejected
   ✗ failed diy, err: failed to load config: fetching manifest: could not load manifest " <insert-oci-image-here>/manifests/sha256:wrongsha" - 404 Not Found

checking image with voucher failed: image failed to pass required check(s)
exit status 1
```